### PR TITLE
fix vagrant install to run out of the box

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -3,7 +3,7 @@
 
 Vagrant.configure("2") do |config|
   config.vm.box = "ubuntu/trusty64"
-  config.vm.network :forwarded_port, guest: 80, host: 3000
+  config.vm.network :forwarded_port, guest: 3000, host: 3000
 
   config.vm.synced_folder ".", "/opt/semaphore",
     type: "rsync",

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -3,7 +3,7 @@
 
 Vagrant.configure("2") do |config|
   config.vm.box = "ubuntu/trusty64"
-  config.vm.network :forwarded_port, guest: 3000, host: 3000
+  config.vm.network :forwarded_port, guest: 80, host: 3000
 
   config.vm.synced_folder ".", "/opt/semaphore",
     type: "rsync",

--- a/playbooks/playbook.yml
+++ b/playbooks/playbook.yml
@@ -35,7 +35,7 @@
       - shell: chown -R {{ username }} {{ homedir }}
 
       # copy over the example credentials
-      - shell: cp -p {{ homedir }}/lib/credentials.example.json {{ homedir }}/lib/credentials.json
+      - shell: cp -p {{ homedir }}/lib/credentials.default.json {{ homedir }}/lib/credentials.json
 
       # Setup runit and logging to /var/log/runit_semaphore
       - file: path={{ homedir }}/runit_semaphore/log state=directory

--- a/playbooks/run_semaphore
+++ b/playbooks/run_semaphore
@@ -1,4 +1,4 @@
 #!/bin/bash
 
 cd /opt/semaphore/
-exec grunt serve
+node bin/semaphore.js

--- a/playbooks/run_semaphore
+++ b/playbooks/run_semaphore
@@ -1,4 +1,4 @@
 #!/bin/bash
 
 cd /opt/semaphore/
-node bin/semaphore.js
+PORT=3000 node bin/semaphore.js


### PR DESCRIPTION
Get the vagrant deploy working out of the box:

* fixed copy of the credentials in playbook
* run with `node` command instead of `grunt`