### PR TITLE
ssh user per host in inventory

### DIFF
--- a/lib/models/Host.js
+++ b/lib/models/Host.js
@@ -8,6 +8,7 @@ var schema = mongoose.Schema({
 	},
 	name: String,
 	hostname: String,
+	username: String,
 	group: {
 		type: ObjectId,
 		ref: 'HostGroup'
@@ -20,7 +21,8 @@ var schema = mongoose.Schema({
 
 schema.index({
 	name: 1,
-	hostname: 1
+	hostname: 1,
+	username: 1
 });
 
 module.exports = mongoose.model('Host', schema);

--- a/lib/routes/host/host.js
+++ b/lib/routes/host/host.js
@@ -51,7 +51,8 @@ function addHost (req, res) {
 		group: req.hostgroup._id,
 		playbook: req.playbook._id,
 		name: req.body.name,
-		hostname: req.body.hostname
+		hostname: req.body.hostname,
+		username: req.body.username
 	});
 	
 	host.save(function () {

--- a/lib/runner.js
+++ b/lib/runner.js
@@ -155,7 +155,11 @@ function setupHosts (task, playbook, done) {
 				hostfile += "["+group.name+"]\n";
 
 				for (var i = 0; i < hosts.length; i++) {
-					hostfile += hosts[i].hostname+"\n";
+					hostfile += hosts[i].hostname
+					if ( host[i].username && host[i].username.length > 0 ) {
+						hostfile += " ansible_ssh_user="+hosts[i].username;
+					}
+					hostfile += "\n";
 				}
 
 				cb();

--- a/lib/views/playbook/hosts.jade
+++ b/lib/views/playbook/hosts.jade
@@ -16,13 +16,17 @@ div(ng-repeat="hostgroup in hostgroups.hostgroups")
 			label.control-label.col-sm-4 Hostname
 			.col-sm-7
 				input.form-control(type="text" placeholder="Hostname" ng-model="hostgroup.newHost.data.hostname")
+		.form-group
+			label.control-label.col-sm-4 Username
+			.col-sm-7
+				input.form-control(type="text" placeholder="Username" ng-model="hostgroup.newHost.data.username")
 
 		.form-group
 			.col-sm-7.col-sm-offset-4
 				button.btn.btn-default(ng-click="addHost(hostgroup)") Add Host
 
 	div(ng-repeat="host in hostgroup.hosts")
-		h4 {{ host.data.name }} ({{ host.data.hostname }})
+		h4 {{ host.data.name }} ({{ host.data.username }}@{{ host.data.hostname }})
 			.btn-group.pull-right
 				button.btn.btn-danger.btn-xs(ng-click="deleteHost(hostgroup, host)"): i.fa.fa-trash-o.fa-fw
 		.clearfix


### PR DESCRIPTION
This feature make the user able to specify a ssh user per host. I had this need in my production environment to massively deploy monitoring tools ( monitoring username depending of the linux version in our environments )