### PR TITLE
Write a key pair by identity name

### DIFF
--- a/lib/runner.js
+++ b/lib/runner.js
@@ -83,7 +83,7 @@ function installHostKeys (task, playbook, done) {
 	// Install the private key
 	playbookOutputHandler.call(task, "Updating SSH Keys\n");
 
-	var location = '/root/.ssh/id_rsa';
+	var location = '/root/.ssh/' + playbook.identity.name;
 	fs.mkdir('/root/.ssh', 448, function() {
 		async.parallel([
 			function (done) {
@@ -118,7 +118,7 @@ function pullGit (task, playbook, done) {
 	// Pull from git
 	playbookOutputHandler.call(task, "\nDownloading Playbook.\n");
 
-	var install = spawn(config.path+"/scripts/pullGit.sh", [playbook.location, 'playbook_'+playbook._id], {
+	var install = spawn(config.path+"/scripts/pullGit.sh", [playbook.location, 'playbook_'+playbook._id, playbook.identity.name], {
 		cwd: '/root/',
 		env: {
 			HOME: '/root/',
@@ -185,7 +185,7 @@ function playTheBook (task, playbook, done) {
 	}
 
 	// private key to login to server[s]
-	args.push('--private-key=/root/.ssh/id_rsa');
+	args.push('--private-key=/root/.ssh/' + playbook.identity.name );
 
 	// the playbook file
 	args.push(task.job.play_file);

--- a/lib/scripts/pullGit.sh
+++ b/lib/scripts/pullGit.sh
@@ -1,10 +1,10 @@
 #!/bin/bash
 
-printf "#\041/bin/bash\nssh -i /root/.ssh/id_rsa \$1 \$2\n" > /root/ssh_wrapper.sh
-chmod +x /root/ssh_wrapper.sh
+printf "#\041/bin/bash\nssh -i /root/.ssh/$3 \$1 \$2\n" > /root/ssh_wrapper_$3.sh
+chmod +x /root/ssh_wrapper_$3.sh
 
 cd /root
-GIT_SSH=/root/ssh_wrapper.sh git clone "$1" $2
+GIT_SSH=/root/ssh_wrapper_$3.sh git clone "$1" $2
 if [ $? -ne 0 ]; then
 	exit 2
 fi


### PR DESCRIPTION
Avoid to rewrite all the time the default private/public key of the user running semaphore by creating a keypair by identity.