### PR TITLE
Replace root home with home of the semaphore user

### DIFF
--- a/lib/runner.js
+++ b/lib/runner.js
@@ -6,6 +6,9 @@ var config = require('./config'),
 	models = require('./models'),
 	app = require('./app');
 
+var home = process.env.HOME + '/';
+var user = process.env.USER;
+
 exports.queue = async.queue(worker, 1);
 
 function worker (task, callback) {
@@ -65,7 +68,7 @@ function worker (task, callback) {
 			task.status = 'Completed';
 		}
 
-		var rmrf = spawn('rm', ['-rf', '/root/playbook_'+task.playbook])
+		var rmrf = spawn('rm', ['-rf', home + 'playbook_'+task.playbook])
 		rmrf.on('close', function () {
 			app.io.emit('playbook.update', {
 				task_id: task._id,
@@ -83,8 +86,8 @@ function installHostKeys (task, playbook, done) {
 	// Install the private key
 	playbookOutputHandler.call(task, "Updating SSH Keys\n");
 
-	var location = '/root/.ssh/id_rsa';
-	fs.mkdir('/root/.ssh', 448, function() {
+	var location = home + '.ssh/id_rsa';
+	fs.mkdir( home + '.ssh', 448, function() {
 		async.parallel([
 			function (done) {
 				fs.writeFile(location, playbook.identity.private_key, {
@@ -103,7 +106,7 @@ function installHostKeys (task, playbook, done) {
   PasswordAuthentication no\n\
   PreferredAuthentications publickey\n";
 
-				fs.writeFile('/root/.ssh/config', config, {
+				fs.writeFile(home + '.ssh/config', config, {
 					mode: 420 // 0644
 				}, done);
 			}
@@ -119,13 +122,13 @@ function pullGit (task, playbook, done) {
 	playbookOutputHandler.call(task, "\nDownloading Playbook.\n");
 
 	var install = spawn(config.path+"/scripts/pullGit.sh", [playbook.location, 'playbook_'+playbook._id], {
-		cwd: '/root/',
+		cwd: home,
 		env: {
-			HOME: '/root/',
-			OLDPWD: '/root/',
-			PWD: '/root/',
-			LOGNAME: 'root',
-			USER: 'root',
+			HOME: home,
+			OLDPWD: home,
+			PWD: home,
+			LOGNAME: user,
+			USER: user,
 			TERM: 'xterm',
 			SHELL: '/bin/bash',
 			PATH: '/usr/local/sbin:/usr/local/bin:/sbin:/bin:/usr/sbin:/usr/bin:/root/bin',
@@ -163,7 +166,7 @@ function setupHosts (task, playbook, done) {
 		}, function () {
 			playbookOutputHandler.call(task, "\nSet up Ansible Hosts file with contents:\n"+hostfile+"\n");
 
-			fs.writeFile('/root/playbook_'+playbook._id+'/semaphore_hosts', hostfile, function (err) {
+			fs.writeFile(home + 'playbook_'+playbook._id+'/semaphore_hosts', hostfile, function (err) {
 				done(err, task, playbook);
 			});
 		});
@@ -171,7 +174,7 @@ function setupHosts (task, playbook, done) {
 }
 
 function setupVault (task, playbook, done) {
-	fs.writeFile('/root/playbook_'+playbook._id+'/semaphore_vault_pwd', playbook.vault_password, function (err) {
+	fs.writeFile(home + 'playbook_'+playbook._id+'/semaphore_vault_pwd', playbook.vault_password, function (err) {
 		done(err, task, playbook);
 	})
 }
@@ -185,19 +188,19 @@ function playTheBook (task, playbook, done) {
 	}
 
 	// private key to login to server[s]
-	args.push('--private-key=/root/.ssh/id_rsa');
+	args.push('--private-key=' + home + '.ssh/id_rsa');
 
 	// the playbook file
 	args.push(task.job.play_file);
 
 	var playbook = spawn("ansible-playbook", args, {
-		cwd: '/root/playbook_'+playbook._id,
+		cwd: home + 'playbook_'+playbook._id,
 		env: {
-			HOME: '/root/',
-			OLDPWD: '/root/',
-			PWD: '/root/playbook_'+playbook._id,
-			LOGNAME: 'root',
-			USER: 'root',
+			HOME: home,
+			OLDPWD: home,
+			PWD: home + 'playbook_'+playbook._id,
+			LOGNAME: user,
+			USER: user,
 			TERM: 'xterm',
 			SHELL: '/bin/bash',
 			PATH: '/usr/local/sbin:/usr/local/bin:/sbin:/bin:/usr/sbin:/usr/bin:/root/bin',

--- a/lib/scripts/pullGit.sh
+++ b/lib/scripts/pullGit.sh
@@ -1,10 +1,10 @@
 #!/bin/bash
 
-printf "#\041/bin/bash\nssh -i /root/.ssh/id_rsa \$1 \$2\n" > /root/ssh_wrapper.sh
-chmod +x /root/ssh_wrapper.sh
+printf "#\041/bin/bash\nssh -i \"$HOME/.ssh/id_rsa\" \$1 \$2\n" > $HOME/ssh_wrapper.sh
+chmod +x $HOME/ssh_wrapper.sh
 
-cd /root
-GIT_SSH=/root/ssh_wrapper.sh git clone "$1" $2
+cd $HOME
+GIT_SSH=$HOME/ssh_wrapper.sh git clone "$1" $2
 if [ $? -ne 0 ]; then
 	exit 2
 fi


### PR DESCRIPTION
Hi,

I replaced the '/root/' with the actual home of the running user. So one can start semaphore as a normal user. 

Fixes #39 