### PR TITLE
If users in db don't create default user (fixes #48)

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -61,12 +61,11 @@ exports.init = function () {
 	var models = require('./models');
 
 	models.User.findOne({
-		email: 'admin@semaphore.local'
-	}).exec(function (err, admin) {
-		if (!admin) {
+	}).exec(function (err, user) {
+		if (!user) {
 			console.log("Creating Admin user admin@semaphore.local!");
 
-			admin = new models.User({
+			var admin = new models.User({
 				email: 'admin@semaphore.local',
 				username: 'semaphore',
 				name: 'Administrator'


### PR DESCRIPTION
If there are any users in the DB skip the creation of the default admin.

When user starts the app from scratch the default admin is created. If the user adds another admin and deletes the default user,
the default admin will not be created.
If there is the case that the user deletes all admins (including the one he is using right now) the default admin is created again.

This fixes bug #48 which can be a security issue for open deploys of semaphore application.