### PR TITLE
Added `tini' to reap zombies - a well-known issue with PID 1 process.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,6 +9,12 @@ WORKDIR /srv/semaphore
 RUN npm install
 RUN ./node_modules/.bin/bower install --allow-root
 
+ENV TINI_VERSION v0.9.0
+ADD https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini /tini
+RUN chmod +x /tini
+
+ENTRYPOINT [ "/tini", "--" ]
+
 ENV NODE_ENV production
 ENV REDIS_PORT 6379
 CMD ["node", "/srv/semaphore/bin/semaphore"]


### PR DESCRIPTION
Every job run runner.js leaves a "defunct" pullGit.sh. Please see https://blog.phusion.nl/2015/01/20/docker-and-the-pid-1-zombie-reaping-problem/ for details.