### PR TITLE
Inject ansible-playbook executable options using job definition

### DIFF
--- a/lib/models/Job.js
+++ b/lib/models/Job.js
@@ -12,6 +12,7 @@ var schema = mongoose.Schema({
 	},
 	name: String,
 	play_file: String, //x.yml
+	exec_options: String,
 	extra_vars: String,
 	use_vault: Boolean
 });

--- a/lib/routes/job/job.js
+++ b/lib/routes/job/job.js
@@ -50,6 +50,7 @@ function remove (req, res) {
 function save (req, res) {
 	req.job.name = req.body.name;
 	req.job.play_file = req.body.play_file;
+	req.job.exec_options = req.body.exec_options;
 	req.job.extra_vars = req.body.extra_vars;
 
 	req.job.save();

--- a/lib/routes/job/jobs.js
+++ b/lib/routes/job/jobs.js
@@ -37,6 +37,7 @@ function add (req, res) {
 		playbook: req.playbook._id,
 		name: req.body.name,
 		play_file: req.body.play_file,
+		exec_options: req.body.exec_options,
 		extra_vars: req.body.extra_vars,
 		use_vault: req.body.use_vault
 	})

--- a/lib/runner.js
+++ b/lib/runner.js
@@ -209,6 +209,14 @@ function playTheBook (task, playbook, done) {
 		}
 	}
 
+	if(task.job.exec_options.length>0){
+		var opts = task.job.exec_options.split(" ");
+
+		for (var i=0; i < opts.length; i++){
+			args.push(opts[i]);
+		}
+	}
+
 	console.log(args);
 
 	var playbook = spawn("ansible-playbook", args, {

--- a/lib/views/playbook/job.jade
+++ b/lib/views/playbook/job.jade
@@ -8,17 +8,20 @@ h1
 			.panel-body
 				form.form-horizontal
 					.form-group
-						label.control-label.col-sm-4 Name
+						label.control-label.col-sm-3 Name
 						.col-sm-7
 							input.form-control(type="text" placeholder="Group Name" ng-model="job.data.name")
 
 					.form-group
-						label.control-label.col-sm-4 Play
+						label.control-label.col-sm-3 Play
 						.col-sm-7
 							input.form-control(type="text" placeholder="myplay.yml" ng-model="job.data.play_file")
-
 					.form-group
-						label.control-label.col-sm-4 Extra vars
+						label.control-label.col-sm-3 Executable Options
+						.col-sm-7
+							input.form-control(type="text" placeholder="-v" ng-model="job.data.exec_options")
+					.form-group
+						label.control-label.col-sm-3 Extra vars
 						.col-sm-7
 							input.form-control(type="text" placeholder="env=prod" ng-model="job.data.extra_vars")
 

--- a/lib/views/playbook/jobs.jade
+++ b/lib/views/playbook/jobs.jade
@@ -6,12 +6,14 @@ table.table.table-hover
 		tr
 			th Job Name
 			th Play File
+			th Executable Options
 			th Extra Vars
 			th &nbsp;
 	tbody
 		tr(ng-repeat="job in jobs.jobs")
 			td {{ job.data.name }}
 			td {{ job.data.play_file }}
+			td {{ job.data.exec_options }}
 			td {{ job.data.extra_vars }}
 			td
 				.btn-group.pull-right


### PR DESCRIPTION
Similar to extra_vars, I created exec_options which will be added to ansible_playbook  [options]. Currently I am using this to view details logs, but it can be generic and all ansible_playbook options can  be sent over. Please include this in master if you find it useful. 

Changes: I changed Job model, job edit template, jobs listing template, and save() and add() methods where Job gets persisted. Also changed runner.js to apply the changes while invoking executable.