### PR TITLE
Prepare repo for automated build on Dockerhub

### DIFF
--- a/Deploy/docker-compose.yml
+++ b/Deploy/docker-compose.yml
@@ -1,30 +1,40 @@
-mysql:
-  image: mysql
-  environment:
-    MYSQL_RANDOM_ROOT_PASSWORD: 'yes'
-    MYSQL_DATABASE: semaphore
-    MYSQL_USER: semaphore
-    MYSQL_PASSWORD: semaphore
-  hostname: mysql
-  expose:
-    - 3306
+version: '2'
 
-semaphore_api:
-  build: api
-  expose:
-    - 3000
-  ports:
-    - 8081:3000
-  links:
-    - mysql:mysql
+services:
+  mysql:
+    image: mysql
+    environment:
+      MYSQL_RANDOM_ROOT_PASSWORD: 'yes'
+      MYSQL_DATABASE: semaphore
+      MYSQL_USER: semaphore
+      MYSQL_PASSWORD: semaphore
+    hostname: mysql
+    expose:
+      - 3306
 
-semaphore_proxy:
-  build: proxy
-  expose:
-    - 443
-    - 80
-  ports:
-    - 8080:80
-    - 8443:443
-  links:
-    - semaphore_api:semaphore_api
+  semaphore_api:
+    image: castawaylabs/semaphore
+    environment:
+      SEMAPHORE_DB_USER: semaphore
+      SEMAPHORE_DB_PASS: semaphore
+      SEMAPHORE_DB_HOST: mysql
+      SEMAPHORE_DB_PORT: 3306
+      SEMAPHORE_DB: semaphore
+      SEMAPHORE_PLAYBOOK_PATH: /etc/semaphore/
+      SEMAPHORE_ADMIN_PASSWORD: cangetin
+      SEMAPHORE_ADMIN_NAME: Default\ Administrator
+      SEMAPHORE_ADMIN_EMAIL: admin@localhost
+      SEMAPHORE_ADMIN: admin
+    expose:
+      - 3000
+    ports:
+      - 8081:3000
+
+  semaphore_proxy:
+    build: proxy
+    expose:
+      - 443
+      - 80
+    ports:
+      - 8080:80
+      - 8443:443

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,17 +1,6 @@
-FROM fedora
+FROM alpine
 
-RUN dnf -y install git ansible mariadb; dnf -y clean all
-
-ENV SEMAPHORE_DB_USER semaphore
-ENV SEMAPHORE_DB_PASS semaphore
-ENV SEMAPHORE_DB_HOST mysql
-ENV SEMAPHORE_DB_PORT 3306
-ENV SEMAPHORE_DB semaphore
-ENV SEMAPHORE_PLAYBOOK_PATH /etc/semaphore/
-ENV SEMAPHORE_ADMIN_PASSWORD cangetin
-ENV SEMAPHORE_ADMIN_NAME Default\ Administrator
-ENV SEMAPHORE_ADMIN_EMAIL admin@localhost
-ENV SEMAPHORE_ADMIN admin
+RUN apk add --no-cache git ansible mysql-client curl
 
 RUN curl -L https://github.com/ansible-semaphore/semaphore/releases/download/v2.0.4/semaphore_linux_amd64 > /usr/bin/semaphore && chmod +x /usr/bin/semaphore && mkdir -p /etc/semaphore/playbooks
 

--- a/semaphore-startup.sh
+++ b/semaphore-startup.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 
 echoerr() { printf "%s\n" "$*" >&2; }
 


### PR DESCRIPTION
Changes done:
- Updated base image from Fedora to Alpine. Reduces the image size from 436MB to 130 MB.
- Moved the docker file and startup script to the root directory
- Removed the ENV variables out of the docker file and into the compose file
- Pointed the compose file to the future image on docker hub
- Adjusted the compose file to use Version 2 syntax, as recommended by Docker

This should make it doable to have an image on Dockerhub to use for people while keeping the functionality of the compose file to create a local stack.