### PR TITLE
add support for git repo tags or branches 

### DIFF
--- a/api/tasks/runner.go
+++ b/api/tasks/runner.go
@@ -10,6 +10,7 @@ import (
 	"os/exec"
 	"strconv"
 	"time"
+	"string"
 
 	database "github.com/ansible-semaphore/semaphore/db"
 	"github.com/ansible-semaphore/semaphore/models"


### PR DESCRIPTION
Correct issue [119](https://github.com/ansible-semaphore/semaphore/issues/119).

With this, you just have to specify the tag or branch at the end of url in the playbook repository definition.
`git://github.com:userspace/reponame.git#tag|branch`

_Full disclosure : I am not a golang dev ;)_