### PR TITLE
Task history: changed status colors

### DIFF
--- a/public/html/projects/dashboard.jade
+++ b/public/html/projects/dashboard.jade
@@ -13,7 +13,7 @@
 		h4.no-top-margin Task history
 		ul.nav.nav-pills.nav-stacked.task-history-list
 			li(ng-repeat="task in tasks"): a(ng-click="openTask(task)" href="#")
-				span(ng-class="{ 'text-warning': task.status == 'waiting' || task.status == 'running', 'text-danger': task.status == 'error', 'text-success': task.status == 'success' }")
+				span(ng-class="{ 'text-muted': task.status == 'waiting', 'text-info': task.status == 'running', 'text-danger': task.status == 'error', 'text-success': task.status == 'success' }")
 					span(ng-if="task.playbook.length == 0") {{ task.tpl_playbook }}
 					span(ng-if="task.playbook.length > 0") {{ task.playbook }}
 				span.pull-right(ng-if="task.status == 'waiting'") {{ task.created | date:'short' }}


### PR DESCRIPTION
Changed text colors for task statuses `waiting` and `running` to less confusing colors
![semaphore-task-history](https://cloud.githubusercontent.com/assets/3428087/20983810/88845f0a-bcc6-11e6-918d-aaf856af1995.png)
