### PR TITLE
fix api breaking of google/go-github

### DIFF
--- a/util/upgrade.go
+++ b/util/upgrade.go
@@ -10,6 +10,7 @@ import (
 	"path/filepath"
 	"runtime"
 	"time"
+	"context"
 
 	"github.com/google/go-github/github"
 )
@@ -96,7 +97,7 @@ func findAsset(release *github.RepositoryRelease) *github.ReleaseAsset {
 func CheckUpdate(version string) error {
 	// fetch releases
 	gh := github.NewClient(nil)
-	releases, _, err := gh.Repositories.ListReleases("ansible-semaphore", "semaphore", nil)
+	releases, _, err := gh.Repositories.ListReleases(context.TODO(), "ansible-semaphore", "semaphore", nil)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
google/go-github broke the api of their functions with google/go-github@23d6cb9
This PR adds the context `context.TODO()` to the call of `gh.Repositories.ListReleases` which is meant to be used "when it's unclear which Context to use or it is not yet available (because the surrounding function has not yet been extended to accept a Context parameter)" (citing https://godoc.org/context)  
I chose this way because AFAIK we don't have much use of the [`context` package](https://golang.org/pkg/context/).  

fixes #267 