### PR TITLE
Fix zombie processes by calling Wait after Command.Run

### DIFF
--- a/api/tasks/runner.go
+++ b/api/tasks/runner.go
@@ -253,6 +253,7 @@ func (t *task) updateRepository() error {
 	}
 
 	t.logCmd(cmd)
+	defer cmd.Wait()
 	return cmd.Run()
 }
 
@@ -277,6 +278,7 @@ func (t *task) runGalaxy() error {
 	}
 
 	t.logCmd(cmd)
+	defer cmd.Wait()
 	return cmd.Run()
 }
 
@@ -327,6 +329,7 @@ func (t *task) runPlaybook() error {
 	cmd.Env = t.envVars(util.Config.TmpPath, cmd.Dir, nil)
 
 	t.logCmd(cmd)
+	defer cmd.Wait()
 	return cmd.Run()
 }
 


### PR DESCRIPTION
There're a lot of zombies created by semaphore(marked with `Zs`). I think we need to call `wait` after every command is finished.

```
$ ps aux | grep ansible
ansible   8004  0.0  0.0      0     0 ?        Zs   13:53   0:00 [ssh] <defunct>
ansible   8005  0.0  0.0      0     0 ?        Zs   13:53   0:00 [ssh] <defunct>
ansible   9833  0.0  0.0      0     0 ?        Zs   13:57   0:00 [ssh] <defunct>
ansible   9834  0.0  0.0      0     0 ?        Zs   13:57   0:00 [ssh] <defunct>
ansible  12939  0.0  0.0      0     0 ?        Zs   14:13   0:00 [ssh] <defunct>
ansible  12940  0.0  0.0      0     0 ?        Zs   14:13   0:00 [ssh] <defunct>
ansible  14075  0.0  0.0      0     0 ?        Zs   14:16   0:00 [ssh] <defunct>
ansible  14076  0.0  0.0      0     0 ?        Zs   14:16   0:00 [ssh] <defunct>
ansible  14522  0.0  0.0      0     0 ?        Zs   14:17   0:00 [ssh] <defunct>
ansible  14523  0.0  0.0      0     0 ?        Zs   14:17   0:00 [ssh] <defunct>
ansible  15799  0.0  0.0      0     0 ?        Zs   14:20   0:00 [ssh] <defunct>
ansible  15800  0.0  0.0      0     0 ?        Zs   14:20   0:00 [ssh] <defunct>
ansible  15874  0.0  0.0      0     0 ?        Zs   11:41   0:00 [ssh] <defunct>
ansible  15875  0.0  0.0      0     0 ?        Zs   11:41   0:00 [ssh] <defunct>
ansible  17503  0.0  0.0      0     0 ?        Zs   11:45   0:00 [ssh] <defunct>
ansible  17504  0.0  0.0      0     0 ?        Zs   11:45   0:00 [ssh] <defunct>
ansible  24142  0.0  0.2  20968 11076 ?        Ssl  Mar07   0:03 semaphore -config /srv/semaphore/semaphore_config.json
ansible  24165  0.0  0.0      0     0 ?        Z    Mar07   0:00 [semaphore] <defunct>
ansible  24179  0.0  0.0  12836     0 ?        Sl   Mar07   0:00 /usr/bin/semaphore -config /srv/semaphore/semaphore_config.json
ansible  29176  0.0  0.0      0     0 ?        Zs   15:32   0:00 [ssh] <defunct>
ansible  29177  0.0  0.0      0     0 ?        Zs   15:32   0:00 [ssh] <defunct>
ansible  29836  0.0  0.0      0     0 ?        Zs   15:34   0:00 [ssh] <defunct>
ansible  29837  0.0  0.0      0     0 ?        Zs   15:34   0:00 [ssh] <defunct>

```


REF: http://stackoverflow.com/questions/36050503/golang-child-processes-become-zombies