### PR TITLE
Provide NULL instead of empty string, when Extra CLI Arguments was deleted

### DIFF
--- a/api/projects/templates.go
+++ b/api/projects/templates.go
@@ -91,6 +91,10 @@ func UpdateTemplate(c *gin.Context) {
 		return
 	}
 
+	if *template.Arguments == "" {
+		template.Arguments = nil
+	}
+
 	if _, err := database.Mysql.Exec("update project__template set ssh_key_id=?, inventory_id=?, repository_id=?, environment_id=?, alias=?, playbook=?, arguments=?, override_args=? where id=?", template.SshKeyID, template.InventoryID, template.RepositoryID, template.EnvironmentID, template.Alias, template.Playbook, template.Arguments, template.OverrideArguments, oldTemplate.ID); err != nil {
 		panic(err)
 	}


### PR DESCRIPTION
Fix for https://github.com/ansible-semaphore/semaphore/issues/171