### PR TITLE
Add more verbosity about tasks to the Events description

### DIFF
--- a/api/tasks/runner.go
+++ b/api/tasks/runner.go
@@ -47,7 +47,7 @@ func (t *task) run() {
 		t.updateStatus()
 
 		objType := "task"
-		desc := "Task ID " + strconv.Itoa(t.task.ID) + " finished"
+		desc := "Task ID " + strconv.Itoa(t.task.ID) + " (" + t.template.Alias + ")" + " finished - " + strings.ToUpper(t.task.Status)
 		if err := (models.Event{
 			ProjectID:   &t.projectID,
 			ObjectType:  &objType,
@@ -75,7 +75,7 @@ func (t *task) run() {
 	}
 
 	objType := "task"
-	desc := "Task ID " + strconv.Itoa(t.task.ID) + " is running"
+	desc := "Task ID " + strconv.Itoa(t.task.ID) + " (" + t.template.Alias + ")" + " is running"
 	if err := (models.Event{
 		ProjectID:   &t.projectID,
 		ObjectType:  &objType,


### PR DESCRIPTION
Currently, there is no fast way to check how (and which) last tasks was executed, especially if they were called from different projects. I added task template name and status (success/error) to the Event.description field (and dashboard log).

![2017-03-21-123849_1366x768_scrot](https://cloud.githubusercontent.com/assets/1083576/24133607/d82fe72a-0e49-11e7-8553-76e535fbd003.png)
