### PR TITLE
Fix nil pointer dereference when updating Template. Solves #337

### DIFF
--- a/api/projects/templates.go
+++ b/api/projects/templates.go
@@ -131,7 +131,7 @@ func UpdateTemplate(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if *template.Arguments == "" {
+	if template.Arguments != nil && *template.Arguments == "" {
 		template.Arguments = nil
 	}
 


### PR DESCRIPTION
When updating a template with empty "Extra CLI Arguments" field, the
template.Arguments pointer becomes nil. The previous check whether this
variable is the empty string fails if it is already nil.
The fix introduces a lazy nil check before the empty string-check.

Solves #337