### PR TITLE
Allow concurrency for tasks that does not collide. Fixes #365

### DIFF
--- a/api/tasks/pool.go
+++ b/api/tasks/pool.go
@@ -3,46 +3,112 @@ package tasks
 import (
 	"fmt"
 	"time"
+
+	"github.com/ansible-semaphore/semaphore/util"
 )
 
 type taskPool struct {
-	queue    []*task
-	register chan *task
-	running  *task
+	queue       []*task
+	register    chan *task
+	activeProj  map[int]*task
+	activeNodes map[string]*task
+	running int
 }
 
 var pool = taskPool{
-	queue:    make([]*task, 0),
-	register: make(chan *task),
-	running:  nil,
+	queue:       make([]*task, 0),
+	register:    make(chan *task),
+	activeProj:  make(map[int]*task),
+	activeNodes: make(map[string]*task),
+	running: 0,
 }
 
+type resourceLock struct {
+	lock     bool
+	holder   *task
+}
+
+var resourceLocker = make(chan *resourceLock)
+
 func (p *taskPool) run() {
-	ticker := time.NewTicker(10 * time.Second)
+
+	defer func() {
+		close(resourceLocker)
+	}()
+
+	ticker := time.NewTicker(5 * time.Second)
 
 	defer func() {
 		ticker.Stop()
 	}()
 
+	// Lock or unlock resources when running a task
+	go func (locker <-chan *resourceLock) {
+		for l := range locker {
+			t := l.holder
+			if l.lock {
+				if p.blocks(t) {
+					panic("Trying to lock an already locked resource!")
+				}
+				p.activeProj[t.projectID] = t
+				for _, node := range t.hosts {
+					p.activeNodes[node] = t
+				}
+				p.running += 1
+			} else {
+				if p.activeProj[t.projectID] == t {
+					delete(p.activeProj, t.projectID)
+				}
+				for _, node := range t.hosts {
+					delete(p.activeNodes, node)
+				}
+				p.running -= 1
+			}
+		}
+	}(resourceLocker)
+
 	for {
 		select {
 		case task := <-p.register:
 			fmt.Println(task)
-			if p.running == nil {
-				go task.run()
-				continue
-			}
-
+			go task.prepareRun()
 			p.queue = append(p.queue, task)
 		case <-ticker.C:
-			if len(p.queue) == 0 || p.running != nil {
+			if len(p.queue) == 0 {
+				continue
+			} else if t := p.queue[0]; t.task.Status != "error" && (!t.prepared || p.blocks(t)) {
+				p.queue = append(p.queue[1:], t)
 				continue
 			}
 
-			fmt.Println("Running a task.")
-			go pool.queue[0].run()
+			if t := pool.queue[0]; t.task.Status != "error" {
+				fmt.Println("Running a task.")
+				resourceLocker <- &resourceLock{lock: true, holder: t,}
+				go t.run()
+			}
 			pool.queue = pool.queue[1:]
 		}
+	}
+}
+
+func (p *taskPool) blocks(t *task) bool {
+	if p.running >= util.Config.MaxParallelTasks {
+		return true
+	}
+	switch util.Config.ConcurrencyMode {
+	case "project":
+		return p.activeProj[t.projectID] != nil
+	case "node":
+		collision := false
+		for _, node := range t.hosts {
+			if p.activeNodes[node] != nil {
+				collision = true
+				break
+			}
+		}
+		return collision
+	default:
+		return p.running > 0
 	}
 }
 

--- a/util/config.go
+++ b/util/config.go
@@ -69,6 +69,10 @@ type configType struct {
 	TelegramAlert bool   `json:"telegram_alert"`
 	TelegramChat  string `json:"telegram_chat"`
 	TelegramToken string `json:"telegram_token"`
+
+	// task concurrency
+	ConcurrencyMode  string `json:"concurrency_mode"`
+	MaxParallelTasks int    `json:"max_parallel_tasks"`
 }
 
 var Config *configType
@@ -149,6 +153,10 @@ func init() {
 
 	if len(Config.TmpPath) == 0 {
 		Config.TmpPath = "/tmp/semaphore"
+	}
+
+	if Config.MaxParallelTasks < 1 {
+		Config.MaxParallelTasks = 10
 	}
 
 	var encryption []byte


### PR DESCRIPTION
Two different concurrency modes are implemented, and is enabled by
setting "concurrency_mode" in the config file to either "project" or "node".

When "project" concurrency is enabled, tasks will run in parallel if and
only if they do not share the same project id, with no regard to the
nodes/hosts that are affected.

When "node" concurrency is enabled, a task will run in parallel if and
only if the hosts affected by tasks already running does not intersect
with the hosts that would be affected by the task in question.

If "concurrency_mode" is not specified, no task will start before the
previous one has finished.

The collision check is based on the output from the "--list-hosts"
argument to ansible, which uses the hosts specified in the inventory.
Thus, if two different hostnames are used that points to the same node,
such as "127.0.0.1" and "localhost", there will be no collision and two
tasks may connect to the same node concurrently. If this behaviour is
not desired, one should make sure to not include aliases for their hosts
in their inventories when enabling concurrency mode.

To restrict the amount of parallel tasks that runs at the same time, one
can add the "max_parallel_tasks" to the config file. This defaults to a
humble 10 if not specified.