### PR TITLE
Use bufio.Reader instead of bufio.Scanner for task logging

### DIFF
--- a/api/tasks/logging.go
+++ b/api/tasks/logging.go
@@ -79,20 +79,17 @@ func Readln(r *bufio.Reader) (string, error) {
 
 func (t *task) logPipe(reader *bufio.Reader) {
 
-	s, e := Readln(reader)
-	for e == nil {
-		t.log(s)
-		s, e = Readln(reader)
+	line, err := Readln(reader)
+	for err == nil {
+		t.log(line)
+		line, err = Readln(reader)
 	}
 
-	/*for reader.Scan() {
-		t.log(reader.Text())
-	}
-
-	if err := reader.Err(); err != nil {
-		t.log("Error scanning input!")
+	if err != nil && err.Error() != "EOF" {
+		fmt.Printf("Failed to read output of command: %s\n", err.Error())
 		panic(err)
-	}*/
+	}
+
 }
 
 func (t *task) logCmd(cmd *exec.Cmd) {

--- a/api/tasks/logging.go
+++ b/api/tasks/logging.go
@@ -64,20 +64,41 @@ func (t *task) updateStatus() {
 	}
 }
 
-func (t *task) logPipe(scanner *bufio.Scanner) {
-	for scanner.Scan() {
-		t.log(scanner.Text())
+func Readln(r *bufio.Reader) (string, error) {
+	var (
+		isPrefix bool  = true
+		err      error = nil
+		line, ln []byte
+	)
+	for isPrefix && err == nil {
+		line, isPrefix, err = r.ReadLine()
+		ln = append(ln, line...)
 	}
-	if err := scanner.Err(); err != nil { // Let's hold on to err...
-		t.log("Error scanning input!") // and use it here.
+	return string(ln), err
+}
+
+func (t *task) logPipe(reader *bufio.Reader) {
+
+	s, e := Readln(reader)
+	for e == nil {
+		t.log(s)
+		s, e = Readln(reader)
+	}
+
+	/*for reader.Scan() {
+		t.log(reader.Text())
+	}
+
+	if err := reader.Err(); err != nil {
+		t.log("Error scanning input!")
 		panic(err)
-	}
+	}*/
 }
 
 func (t *task) logCmd(cmd *exec.Cmd) {
 	stderr, _ := cmd.StderrPipe()
 	stdout, _ := cmd.StdoutPipe()
 
-	go t.logPipe(bufio.NewScanner(stderr))
-	go t.logPipe(bufio.NewScanner(stdout))
+	go t.logPipe(bufio.NewReader(stderr))
+	go t.logPipe(bufio.NewReader(stdout))
 }

--- a/api/tasks/logging.go
+++ b/api/tasks/logging.go
@@ -86,8 +86,8 @@ func (t *task) logPipe(reader *bufio.Reader) {
 	}
 
 	if err != nil && err.Error() != "EOF" {
-		fmt.Printf("Failed to read output of command: %s\n", err.Error())
-		panic(err)
+		//don't panic on this errors, sometimes it throw not dangerous "read |0: file already closed" error
+		fmt.Printf("Failed to read task output: %s\n", err.Error())
 	}
 
 }

--- a/api/tasks/logging.go
+++ b/api/tasks/logging.go
@@ -68,6 +68,10 @@ func (t *task) logPipe(scanner *bufio.Scanner) {
 	for scanner.Scan() {
 		t.log(scanner.Text())
 	}
+	if err := scanner.Err(); err != nil { // Let's hold on to err...
+		t.log("Error scanning input!") // and use it here.
+		panic(err)
+	}
 }
 
 func (t *task) logCmd(cmd *exec.Cmd) {


### PR DESCRIPTION
Fix for https://github.com/ansible-semaphore/semaphore/issues/393

bufio.Reader smarter than bufio.Scanner, it can work with big strings, which not fit in the buffer:

https://golang.org/pkg/bufio/#Scanner

> Scanning stops unrecoverably at EOF, the first I/O error, or a token too large to fit in the buffer. When a scan stops, the reader may have advanced arbitrarily far past the last token. Programs that need more control over error handling or large tokens, or must run sequential scans on a reader, should use bufio.Reader instead.

This PR doesn't provide a full solution for crashes on big outputs. We still need to fix https://github.com/ansible-semaphore/semaphore/issues/132, because displaying a big diff (or a content of the file with many lines) cause an enormous number of database connections (equal to number of lines in diff or file).