### PR TITLE
Move inventory and keys to its own ephimeral temporary directory.

### DIFF
--- a/api/tasks/inventory.go
+++ b/api/tasks/inventory.go
@@ -3,8 +3,6 @@ package tasks
 import (
 	"io/ioutil"
 	"strconv"
-
-	"github.com/ansible-semaphore/semaphore/util"
 )
 
 func (t *task) installInventory() error {
@@ -28,5 +26,5 @@ func (t *task) installStaticInventory() error {
 	t.log("installing static inventory")
 
 	// create inventory file
-	return ioutil.WriteFile(util.Config.TmpPath+"/inventory_"+strconv.Itoa(t.task.ID), []byte(t.inventory.Inventory), 0664)
+	return ioutil.WriteFile(t.tmpdir+"/inventory_"+strconv.Itoa(t.task.ID), []byte(t.inventory.Inventory), 0664)
 }

--- a/db/AccessKey.go
+++ b/db/AccessKey.go
@@ -1,10 +1,6 @@
 package db
 
-import (
-	"strconv"
-
-	"github.com/ansible-semaphore/semaphore/util"
-)
+import "fmt"
 
 type AccessKey struct {
 	ID   int    `db:"id" json:"id"`
@@ -19,6 +15,6 @@ type AccessKey struct {
 	Removed bool `db:"removed" json:"removed"`
 }
 
-func (key AccessKey) GetPath() string {
-	return util.Config.TmpPath + "/access_key_" + strconv.Itoa(key.ID)
+func (key AccessKey) GetPath(tmpdir string) string {
+	return fmt.Sprintf("%s/%s_%d", tmpdir, key.Type, key.ID)
 }


### PR DESCRIPTION
Since runs needs to pass some files and right now those lives around the playbook directory, this pull request moves those files to a temporary directory generated on the default temp directory of the machines.

It moves inventory and keys to its own temporal directory. On task finalization clean folder and its contents

Partly fixes #328.