### PR TITLE
Limit activity and tasks lists in dashboards

### DIFF
--- a/api-docs.yml
+++ b/api-docs.yml
@@ -433,6 +433,16 @@ paths:
             type: array
             items:
               $ref: '#/definitions/Event'
+  /events/last:
+    get:
+      summary: Get last 200 Events related to Semaphore and projects you are part of
+      responses:
+        200:
+          description: Array of events in chronological order
+          schema:
+            type: array
+            items:
+              $ref: '#/definitions/Event'
 
   /project/{project_id}:
     parameters:
@@ -897,6 +907,17 @@ paths:
   /project/{project_id}/tasks:
     parameters:
       - $ref: "#/parameters/project_id"
+    get:
+      tags:
+        - project
+      summary: Get Tasks related to current project
+      responses:
+        200:
+          description: Array of tasks in chronological order
+          schema:
+            type: array
+            items:
+              $ref: '#/definitions/Task'
     post:
       tags:
         - project
@@ -923,6 +944,20 @@ paths:
           description: Task queued
           schema:
             $ref: "#/definitions/Task"
+  /project/{project_id}/tasks/last:
+    parameters:
+      - $ref: "#/parameters/project_id"
+    get:
+      tags:
+        - project
+      summary: Get last 200 Tasks related to current project
+      responses:
+        200:
+          description: Array of tasks in chronological order
+          schema:
+            type: array
+            items:
+              $ref: '#/definitions/Task'
   /project/{project_id}/tasks/{task_id}:
     parameters:
       - $ref: "#/parameters/project_id"

--- a/api/events.go
+++ b/api/events.go
@@ -9,13 +9,17 @@ import (
 	"github.com/masterminds/squirrel"
 )
 
-func getEvents(w http.ResponseWriter, r *http.Request) {
+func getEvents(w http.ResponseWriter, r *http.Request, limit uint64) {
 	user := context.Get(r, "user").(*db.User)
 
 	q := squirrel.Select("event.*, p.name as project_name").
 		From("event").
 		LeftJoin("project as p on event.project_id=p.id").
 		OrderBy("created desc")
+
+	if limit > 0 {
+		q = q.Limit(limit)
+	}
 
 	projectObj, exists := context.GetOk(r, "project")
 	if exists == true {
@@ -63,4 +67,12 @@ func getEvents(w http.ResponseWriter, r *http.Request) {
 	}
 
 	mulekick.WriteJSON(w, http.StatusOK, events)
+}
+
+func getLastEvents(w http.ResponseWriter, r *http.Request) {
+	getEvents(w, r, 200)
+}
+
+func getAllEvents(w http.ResponseWriter, r *http.Request) {
+	getEvents(w, r, 0)
 }

--- a/api/router.go
+++ b/api/router.go
@@ -98,7 +98,8 @@ func Route() mulekick.Router {
 		api.Put("/templates/{template_id}", projects.TemplatesMiddleware, projects.UpdateTemplate)
 		api.Delete("/templates/{template_id}", projects.TemplatesMiddleware, projects.RemoveTemplate)
 
-		api.Get("/tasks", tasks.GetAll)
+		api.Get("/tasks", tasks.GetAllTasks)
+		api.Get("/tasks/last", tasks.GetLastTasks)
 		api.Post("/tasks", tasks.AddTask)
 		api.Get("/tasks/{task_id}/output", tasks.GetTaskMiddleware, tasks.GetTaskOutput)
 		api.Get("/tasks/{task_id}", tasks.GetTaskMiddleware, tasks.GetTask)

--- a/api/router.go
+++ b/api/router.go
@@ -47,7 +47,8 @@ func Route() mulekick.Router {
 
 	api.Get("/projects", projects.GetProjects)
 	api.Post("/projects", projects.AddProject)
-	api.Get("/events", getEvents)
+	api.Get("/events", getAllEvents)
+	api.Get("/events/last", getLastEvents)
 
 	api.Get("/users", getUsers)
 	api.Post("/users", addUser)
@@ -63,7 +64,8 @@ func Route() mulekick.Router {
 		api.Put("", projects.MustBeAdmin, projects.UpdateProject)
 		api.Delete("", projects.MustBeAdmin, projects.DeleteProject)
 
-		api.Get("/events", getEvents)
+		api.Get("/events", getAllEvents)
+		api.Get("/events/last", getLastEvents)
 
 		api.Get("/users", projects.GetUsers)
 		api.Post("/users", projects.MustBeAdmin, projects.AddUser)

--- a/api/tasks/http.go
+++ b/api/tasks/http.go
@@ -48,16 +48,21 @@ func AddTask(w http.ResponseWriter, r *http.Request) {
 	mulekick.WriteJSON(w, http.StatusCreated, taskObj)
 }
 
-func GetAll(w http.ResponseWriter, r *http.Request) {
+func GetTasksList(w http.ResponseWriter, r *http.Request, limit uint64) {
 	project := context.Get(r, "project").(db.Project)
 
-	query, args, _ := squirrel.Select("task.*, tpl.playbook as tpl_playbook, user.name as user_name, tpl.alias as tpl_alias").
+	q := squirrel.Select("task.*, tpl.playbook as tpl_playbook, user.name as user_name, tpl.alias as tpl_alias").
 		From("task").
 		Join("project__template as tpl on task.template_id=tpl.id").
 		LeftJoin("user on task.user_id=user.id").
 		Where("tpl.project_id=?", project.ID).
-		OrderBy("task.created desc").
-		ToSql()
+		OrderBy("task.created desc")
+
+	if limit > 0 {
+		q = q.Limit(limit)
+	}
+
+	query, args, _ := q.ToSql()
 
 	var tasks []struct {
 		db.Task
@@ -71,6 +76,14 @@ func GetAll(w http.ResponseWriter, r *http.Request) {
 	}
 
 	mulekick.WriteJSON(w, http.StatusOK, tasks)
+}
+
+func GetAllTasks(w http.ResponseWriter, r *http.Request) {
+	GetTasksList(w, r, 0)
+}
+
+func GetLastTasks(w http.ResponseWriter, r *http.Request) {
+	GetTasksList(w, r, 200)
 }
 
 func GetTask(w http.ResponseWriter, r *http.Request) {

--- a/public/html/dashboard.pug
+++ b/public/html/dashboard.pug
@@ -10,6 +10,7 @@
 					span(ng-if="event.project_id != null") &nbsp;
 					span(ng-bind="event.object_name")
 					span  - {{ event.description }}
+			button.btn.btn-default.btn-s(ng-click="refresh($lastEvents=false)") Show all events
 		.col-md-4
 			.panel.panel-default
 				.panel-heading Projects

--- a/public/html/projects/dashboard.pug
+++ b/public/html/projects/dashboard.pug
@@ -28,3 +28,4 @@
 				br
 				span &nbsp;
 				span.pull-right(ng-if="task.user_name") by {{ task.user_name }}
+		button.btn.btn-default.btn-s(ng-click="reload($lastTasks=false)") Show all tasks

--- a/public/html/projects/dashboard.pug
+++ b/public/html/projects/dashboard.pug
@@ -8,6 +8,7 @@
 				span(ng-bind="event.object_name")
 				span(ng-if="event.object_name.length > 0")  -&nbsp;
 				span {{ event.description }}
+		button.btn.btn-default.btn-s(ng-click="refreshEvents($lastEvents=false)") Show all events
 
 	.col-sm-5(style="border-left: 1px solid #EEE;")
 		h4.no-top-margin Task history

--- a/public/js/controllers/dashboard.js
+++ b/public/js/controllers/dashboard.js
@@ -2,12 +2,18 @@ define(['controllers/projects/edit'], function () {
 	app.registerController('DashboardCtrl', ['$scope', '$http', '$uibModal', function ($scope, $http, $modal) {
 		$scope.projects = [];
 
-		$scope.refresh = function () {
+		$scope.refresh = function ($lastEvents=true) {
 			$http.get('/projects').success(function (projects) {
 				$scope.projects = projects;
 			});
 
-			$http.get('/events').success(function (events) {
+			if ($lastEvents == true) {
+				$eventsURL = '/events/last'
+			} else {
+				$eventsURL = '/events'
+			}
+
+			$http.get($eventsURL).success(function (events) {
 				$scope.events = events;
 			});
 		}

--- a/public/js/controllers/projects/dashboard.js
+++ b/public/js/controllers/projects/dashboard.js
@@ -1,14 +1,26 @@
 define(['controllers/projects/taskRunner'], function() {
     app.registerController('ProjectDashboardCtrl', ['$scope', '$http', 'Project', '$uibModal', '$rootScope', function($scope, $http, Project, $modal, $rootScope) {
-        $http.get(Project.getURL() + '/events').success(function(events) {
-            $scope.events = events;
+        
+        $scope.refreshEvents = function($lastEvents=true) {
 
-            events.forEach(function(evt) {
-                evt.createdFormatted = moment(evt.created).format('DD/M/YY HH:mm')
-            })
-        });
+            if ($lastEvents == true) {
+                $eventsURL = '/events/last'
+            } else {
+                $eventsURL = '/events'
+            }  
+            
+            $http.get(Project.getURL() + $eventsURL).success(function(events) {
+                $scope.events = events;
+
+                events.forEach(function(evt) {
+                    evt.createdFormatted = moment(evt.created).format('DD/M/YY HH:mm')
+                })
+            });
+
+        }
 
         $scope.reload = function() {
+
             $http.get(Project.getURL() + '/tasks').success(function(tasks) {
                 $scope.tasks = tasks;
 
@@ -31,6 +43,7 @@ define(['controllers/projects/taskRunner'], function() {
                 });
             });
         }
+        $scope.refreshEvents();
         $scope.reload();
 
         $scope.openTask = function(task) {

--- a/public/js/controllers/projects/dashboard.js
+++ b/public/js/controllers/projects/dashboard.js
@@ -19,9 +19,15 @@ define(['controllers/projects/taskRunner'], function() {
 
         }
 
-        $scope.reload = function() {
+        $scope.reload = function($lastEvents=true) {
 
-            $http.get(Project.getURL() + '/tasks').success(function(tasks) {
+            if ($lastEvents == true) {
+                $tasksURL = '/tasks/last'
+            } else {
+                $tasksURL = '/tasks'
+            }  
+
+            $http.get(Project.getURL() + $tasksURL).success(function(tasks) {
                 $scope.tasks = tasks;
 
                 $scope.tasks.forEach(function(t) {


### PR DESCRIPTION
Fix for https://github.com/ansible-semaphore/semaphore/issues/367

I created a simple solution. I added the limit of 200 items to activity and tasks lists and button for all events/tasks loading.

In my case (about 6000 events in the database) this decreased page load time from 15 to 2 seconds.
![2017-07-25-150044_1366x768_scrot](https://user-images.githubusercontent.com/1083576/28556587-98d13aa2-714a-11e7-9831-01503ea42db3.png)
![2017-07-25-150049_1366x768_scrot](https://user-images.githubusercontent.com/1083576/28556586-98cae71a-714a-11e7-8a72-22ed8586dd14.png)

