### PR TITLE
feat(template): hidden templates

### DIFF
--- a/public/html/projects/templates/list.pug
+++ b/public/html/projects/templates/list.pug
@@ -1,7 +1,7 @@
 h3 Task Templates
 	button.btn.btn-success.btn-xs.pull-right(ng-click="add()" style="margin-left: 5px;") New Template
-	button.btn.btn-default.btn-xs.pull-right(ng-if="allShown" ng-click="hideHidden()") Hide Hidden
-	button.btn.btn-default.btn-xs.pull-right(ng-if="!allShown" ng-click="showAll()") Show Hidden
+	button.btn.btn-default.btn-xs.pull-right(ng-if="allShown && hasHiddenTemplates()" ng-click="hideHidden()") Hide Hidden
+	button.btn.btn-default.btn-xs.pull-right(ng-if="!allShown && hasHiddenTemplates()" ng-click="showAll()") Show Hidden
 
 table.table.table-hover
 	thead: tr

--- a/public/html/projects/templates/list.pug
+++ b/public/html/projects/templates/list.pug
@@ -1,5 +1,7 @@
 h3 Task Templates
-	button.btn.btn-success.btn-xs.pull-right(ng-click="add()") New Template
+	button.btn.btn-success.btn-xs.pull-right(ng-click="add()" style="margin-left: 5px;") New Template
+	button.btn.btn-default.btn-xs.pull-right(ng-if="allShown" ng-click="hideHidden()") Hide Hidden
+	button.btn.btn-default.btn-xs.pull-right(ng-if="!allShown" ng-click="showAll()") Show Hidden
 
 table.table.table-hover
 	thead: tr
@@ -10,7 +12,7 @@ table.table.table-hover
 		th Environment
 		th Repository
 		th &nbsp;
-	tbody: tr(ng-repeat="tpl in templates" ng-click="update(tpl)" style="cursor: pointer;")
+	tbody: tr(ng-repeat="tpl in templates" ng-click="update(tpl)" style="cursor: pointer;" ng-if="!tpl.hidden || allShown")
 		td {{ tpl.alias }}
 		td {{ tpl.playbook }}
 		td {{ sshKeysAssoc[tpl.ssh_key_id].name }}
@@ -18,5 +20,7 @@ table.table.table-hover
 		td {{ environmentAssoc[tpl.environment_id].name }}
 		td {{ reposAssoc[tpl.repository_id].name }}
 		td: .pull-right
-			button.btn.btn-info.btn-xs(ng-click="copy(tpl); $event.stopPropagation();") copy
-			button.btn.btn-success.btn-xs(ng-click="run(tpl); $event.stopPropagation();", style="margin-left: 5px;") run
+			button.btn.btn-default.btn-xs(ng-if="!tpl.hidden" ng-click="hideTemplate(tpl); $event.stopPropagation();") hide
+			button.btn.btn-default.btn-xs(ng-if="tpl.hidden" ng-click="showTemplate(tpl); $event.stopPropagation();") show
+			button.btn.btn-info.btn-xs(ng-click="copy(tpl); $event.stopPropagation();" style="margin-left: 5px;") copy
+			button.btn.btn-success.btn-xs(ng-click="run(tpl); $event.stopPropagation();" style="margin-left: 5px;") run

--- a/public/js/controllers/projects/templates.js
+++ b/public/js/controllers/projects/templates.js
@@ -51,9 +51,9 @@ define(['controllers/projects/taskRunner'], function () {
 			$window.localStorage.setItem('hidden-templates', JSON.stringify(hiddenTemplates));
 		}
 
-    $scope.hasHiddenTemplates = function() {
-      return getHiddenTemplates().length > 0;
-    }
+		$scope.hasHiddenTemplates = function() {
+			return getHiddenTemplates().length > 0;
+		}
 
 		$scope.reload = function () {
 			$http.get(Project.getURL() + '/templates?sort=alias&order=asc').success(function (templates) {

--- a/public/js/controllers/projects/templates.js
+++ b/public/js/controllers/projects/templates.js
@@ -51,7 +51,7 @@ define(['controllers/projects/taskRunner'], function () {
 			$window.localStorage.setItem('hidden-templates', JSON.stringify(hiddenTemplates));
 		}
 
-    function hasHiddenTemplates() {
+    $scope.hasHiddenTemplates = function() {
       return getHiddenTemplates().length > 0;
     }
 

--- a/public/js/controllers/projects/templates.js
+++ b/public/js/controllers/projects/templates.js
@@ -41,7 +41,7 @@ define(['controllers/projects/taskRunner'], function () {
 
 		function getHiddenTemplates() {
 			try {
-				return JSON.parse($window.localStorage.getItem('hidden-templates') || '[]')
+				return JSON.parse($window.localStorage.getItem('hidden-templates') || '[]');
 			} catch(e) {
 				return [];
 			}
@@ -51,10 +51,14 @@ define(['controllers/projects/taskRunner'], function () {
 			$window.localStorage.setItem('hidden-templates', JSON.stringify(hiddenTemplates));
 		}
 
+    function hasHiddenTemplates() {
+      return getHiddenTemplates().length > 0;
+    }
+
 		$scope.reload = function () {
 			$http.get(Project.getURL() + '/templates?sort=alias&order=asc').success(function (templates) {
 				var hiddenTemplates = getHiddenTemplates();
-				for (var i in templates) {
+				for (var i = 0; i < templates.length; i++) {
 					var template = templates[i];
 					if (hiddenTemplates.indexOf(template.id) !== -1) {
 						template.hidden = true;


### PR DESCRIPTION
Add ability to hide templates in the list.

This commit:
- adds button "hide" to each row in the template list. 
- adds button "show hidden" on top of the template list to show hidden templates.

IDs of hidden templates stores to localStorage item "hidden-templates".