### PR TITLE
add link to JSON task output in task info

### DIFF
--- a/public/html/projects/taskModal.pug
+++ b/public/html/projects/taskModal.pug
@@ -12,6 +12,9 @@
 		dd {{ task.endFormatted }}
 		dt Created
 		dd {{ task.createdFormatted }}
+		dt Permalink
+		dd 
+			a(href="{{ task.URL }}") Output
 		dt Raw output
 		dd: input(type="checkbox" ng-model="raw" title="show logs unbesmirched")
 

--- a/public/js/controllers/projects/dashboard.js
+++ b/public/js/controllers/projects/dashboard.js
@@ -44,7 +44,7 @@ define(['controllers/projects/taskRunner'], function() {
                     if (!t.start || !t.end) {
                         return;
                     }
-
+                    t.URL = '/api' + $scope.project.getURL() + '/tasks/' + t.id + '/output'
                     t.duration = moment(t.end).diff(moment(t.start), 'minutes');
                 });
             });


### PR DESCRIPTION
Small improvement for https://github.com/ansible-semaphore/semaphore/issues/314
Now, we can get permalink to the task output (in JSON, unfortunately, I'm not so good in JS to create new page from scratch) directly from task log:

![2017-11-14-160449_1366x768_scrot](https://user-images.githubusercontent.com/1083576/32765315-96479840-c955-11e7-896a-80b420467591.png)


P.S. @matejkramny we miss you! :)