### PR TITLE
Fix crash when new role added to requirements

### DIFF
--- a/api/tasks/runner.go
+++ b/api/tasks/runner.go
@@ -98,6 +98,12 @@ func (t *task) prepareRun() {
 		return
 	}
 
+	if err := t.runGalaxy(); err != nil {
+		t.log("Running galaxy failed: " + err.Error())
+		t.fail()
+		return
+	}
+
 	// todo: write environment
 
 	if err := t.listPlaybookHosts(); err != nil {
@@ -153,12 +159,6 @@ func (t *task) run() {
 
 	t.log("Started: " + strconv.Itoa(t.task.ID))
 	t.log("Run task with template: " + t.template.Alias + "\n")
-
-	if err := t.runGalaxy(); err != nil {
-		t.log("Running galaxy failed: " + err.Error())
-		t.fail()
-		return
-	}
 
 	if err := t.runPlaybook(); err != nil {
 		t.log("Running playbook failed: " + err.Error())


### PR DESCRIPTION
fix for https://github.com/ansible-semaphore/semaphore/issues/441

I just moved `runGalaxy()` from `Task Run` to `Task Prepare` step. @Natanande, can you review it? This bug caused by task concurrency code