### PR TITLE
Fix stdIn hanging issue

### DIFF
--- a/api/tasks/runner.go
+++ b/api/tasks/runner.go
@@ -372,6 +372,7 @@ func (t *task) runPlaybook() error {
 	cmd.Env = t.envVars(util.Config.TmpPath, cmd.Dir, nil)
 
 	t.logCmd(cmd)
+	cmd.Stdin = strings.NewReader("")
 	return cmd.Run()
 }
 


### PR DESCRIPTION
I had an issue with Semaphore where trying to connect to a host that is not already in the known hosts list would ask you if you wished to add them to the known_hosts. This would cause semaphore to be unable to start any other task and a restart would be needed.
With this fix I simply attach a blank string as stdin to the playbook run command, which causes the host key verification to fail in this instance