### PR TITLE
Openshift Template

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,6 +11,8 @@ EXPOSE 3000
 ADD ./scripts/docker-startup.sh /usr/bin/semaphore-startup.sh
 RUN chmod +x /usr/bin/semaphore-startup.sh
 
+USER 1001
+
 ENTRYPOINT ["/sbin/tini", "--"]
 
 CMD ["/usr/bin/semaphore-startup.sh", "/usr/bin/semaphore", "-config", "/etc/semaphore/semaphore_config.json"]

--- a/openshift/README.md
+++ b/openshift/README.md
@@ -1,0 +1,15 @@
+# Deploying Semaphore on Openshift
+
+This is intended as a quick starter config to get semaphore up and running using only the docker hub image.
+The config is set to periodically pull new versions of the image from docker hub.
+
+You may wish to tweak this once imported or choose to build the image within openshift itself
+
+Your openshift cluster needs to have the mysql-persistent template installed, but it comes as default so it should be
+```
+oc new-project semaphore
+oc create -fopenshift/template.yml
+oc new-app mysql-persistent -p MYSQL_DATABASE=semaphore
+oc new-app semaphore
+```
+It will take some moments for the application to become available (mainly due to the mysql pod startup time), after this the web ui will be available on http://semaphore-semaphore.127.0.0.1.nip.io/auth/login (if running your oc cluster locally and you did not override the url via parameters). You can login with the default values

--- a/openshift/template.yml
+++ b/openshift/template.yml
@@ -1,0 +1,162 @@
+apiVersion: v1
+kind: Template
+metadata:
+  name: semaphore
+objects:
+- apiVersion: v1
+  kind: ImageStream
+  metadata:
+    name: semaphore
+    labels:
+      app: semaphore
+  spec:
+    tags:
+    - name: latest
+      from:
+        kind: DockerImage
+        name: docker.io/castawaylabs/semaphore:latest
+      importPolicy:
+        scheduled: true
+- apiVersion: v1
+  kind: PersistentVolumeClaim
+  metadata:
+    name: semaphore-data
+  spec:
+    accessModes:
+    - ReadWriteOnce
+    resources:
+      requests:
+        storage: 10Gi
+  status: {}
+- apiVersion: v1
+  kind: DeploymentConfig
+  metadata:
+    annotations:
+      openshift.io/generated-by: OpenShiftNewApp
+    creationTimestamp: null
+    generation: 1
+    labels:
+      app: semaphore
+    name: semaphore
+  spec:
+    replicas: 1
+    selector:
+      app: semaphore
+      deploymentconfig: semaphore
+    strategy:
+      activeDeadlineSeconds: 21600
+      resources: {}
+      rollingParams:
+        intervalSeconds: 1
+        maxSurge: 25%
+        maxUnavailable: 25%
+        timeoutSeconds: 600
+        updatePeriodSeconds: 1
+      type: Rolling
+    template:
+      metadata:
+        annotations:
+          openshift.io/generated-by: OpenShiftNewApp
+        creationTimestamp: null
+        labels:
+          app: semaphore
+          deploymentconfig: semaphore
+      spec:
+        containers:
+        - env:
+          - name: SEMAPHORE_DB_HOST
+            value: mysql
+          - name: SEMAPHORE_DB
+            value: semaphore
+          - name: SEMAPHORE_DB_PASS
+            valueFrom:
+              secretKeyRef:
+                key: database-password
+                name: mysql
+          - name: SEMAPHORE_DB_USER
+            valueFrom:
+              secretKeyRef:
+                key: database-user
+                name: mysql
+          - name: SEMAPHORE_PLAYBOOK_PATH
+            value: /tmp/semaphore
+          image: castawaylabs/semaphore@sha256:49418844c527719558895308aca362fd544442d41d93b60d4684db97abedd19c
+          imagePullPolicy: Always
+          name: semaphore
+          ports:
+          - containerPort: 3000
+            protocol: TCP
+          resources: {}
+          terminationMessagePath: /dev/termination-log
+          terminationMessagePolicy: File
+          volumeMounts:
+          - mountPath: /etc/semaphore
+            name: semaphore-etc
+            subPath: etc
+        dnsPolicy: ClusterFirst
+        restartPolicy: Always
+        schedulerName: default-scheduler
+        securityContext: {}
+        terminationGracePeriodSeconds: 30
+        volumes:
+        - name: semaphore-etc
+          persistentVolumeClaim:
+            claimName: semaphore-data
+    test: false
+    triggers:
+    - type: ConfigChange
+    - imageChangeParams:
+        automatic: true
+        containerNames:
+        - semaphore
+        from:
+          kind: ImageStreamTag
+          name: semaphore:latest
+          namespace: semaphore
+      type: ImageChange
+- apiVersion: v1
+  kind: Route
+  metadata:
+    annotations:
+      openshift.io/host.generated: "true"
+    creationTimestamp: null
+    name: semaphore
+  spec:
+    host: semaphore-semaphore.127.0.0.1.nip.io
+    port:
+      targetPort: 3000-tcp
+    to:
+      kind: Service
+      name: semaphore
+      weight: 100
+    wildcardPolicy: None
+  status:
+    ingress:
+    - conditions:
+      - lastTransitionTime: 2018-02-09T17:53:41Z
+        status: "True"
+        type: Admitted
+      routerName: router
+      wildcardPolicy: None
+- apiVersion: v1
+  kind: Service
+  metadata:
+    annotations:
+      openshift.io/generated-by: OpenShiftNewApp
+    creationTimestamp: null
+    labels:
+      app: semaphore
+    name: semaphore
+  spec:
+    ports:
+    - name: 3000-tcp
+      port: 3000
+      protocol: TCP
+      targetPort: 3000
+    selector:
+      app: semaphore
+      deploymentconfig: semaphore
+    sessionAffinity: None
+    type: ClusterIP
+  status:
+    loadBalancer: {}

--- a/openshift/template.yml
+++ b/openshift/template.yml
@@ -14,7 +14,7 @@ objects:
     - name: latest
       from:
         kind: DockerImage
-        name: docker.io/castawaylabs/semaphore:latest
+        name: "${SEMAPHORE_IMAGE_SOURCE}"
       importPolicy:
         scheduled: true
 - apiVersion: v1
@@ -26,7 +26,7 @@ objects:
     - ReadWriteOnce
     resources:
       requests:
-        storage: 10Gi
+        storage: "${SEMAPHORE_DATA_VOLUME_SIZE}Gi"
   status: {}
 - apiVersion: v1
   kind: DeploymentConfig
@@ -80,7 +80,6 @@ objects:
                 name: mysql
           - name: SEMAPHORE_PLAYBOOK_PATH
             value: /tmp/semaphore
-          image: castawaylabs/semaphore@sha256:49418844c527719558895308aca362fd544442d41d93b60d4684db97abedd19c
           imagePullPolicy: Always
           name: semaphore
           ports:
@@ -112,7 +111,6 @@ objects:
         from:
           kind: ImageStreamTag
           name: semaphore:latest
-          namespace: semaphore
       type: ImageChange
 - apiVersion: v1
   kind: Route
@@ -122,7 +120,7 @@ objects:
     creationTimestamp: null
     name: semaphore
   spec:
-    host: semaphore-semaphore.127.0.0.1.nip.io
+    host: "${SEMAPHORE_URL}"
     port:
       targetPort: 3000-tcp
     to:
@@ -160,3 +158,21 @@ objects:
     type: ClusterIP
   status:
     loadBalancer: {}
+
+
+parameters:
+  - name: SEMAPHORE_IMAGE_SOURCE
+    displayName: Semaphore image
+    description: The id of the repository from which to pull the semaphore image
+    value: docker.io/castawaylabs/semaphore:latest
+    required: true
+  - name: SEMAPHORE_DATA_VOLUME_SIZE
+    displayName: Semaphore data volume size
+    description: The size, in Gi of the semaphore data volume, which is mounted at /etc/semaphore
+    value: "5"
+    required: true
+  - name: SEMAPHORE_URL
+    displayName: URL
+    description: Set this to the value which you wish to be passed to the route. If blank will use generated url
+    required: false
+


### PR DESCRIPTION
Just a quick PR to add a template to start Semaphore in openshift (using the openshift mysql-persistent template for storage).
It works when I test it but it would be great if someone else could test it on their own cluster, or in the redhat public cluster. Check the readme in the openshift folder for usage details.

It could also probably do with an nginx container in front of it, could be pretty simple as all the ssl can be done on the edge by openshift, but for now would just be great if some other openshift users could test it.

In future perhaps it would be good to also have a template that builds the image on openshift directly from the repo code.