### PR TITLE
Add binaries to gitignore and remove binddata.go

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ node_modules
 
 .idea/
 caddyfile
+cli/semaphore_*


### PR DESCRIPTION
I found ```util/binddata.go``` in ```.gitignore``` but file isnt't deleted. I've deleted it.

Also added ```cli/semahore_*``` to gitignore.