### PR TITLE
add version code generator

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ node_modules
 caddyfile
 cli/semaphore_*
 *-packr.go
+util/version.go

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -5,9 +5,6 @@
 # internally by other tasks and therefore are not listed when running `task` or `task -l`
 version: '2'
 
-vars:
-  VERSION: '2.5.0-dev'
-
 tasks:
   all:
     desc: Install, Compile, Test and Build Semaphore for local architecture
@@ -78,11 +75,22 @@ tasks:
       - api/api-packr.go
     cmds:
       - packr
+      - go run util/version_gen/generator.go {{ if .TAG }}{{ .TAG }}{{ else }}{{ if .SEMAPHORE_VERSION }}{{ .SEMAPHORE_VERSION }}{{ else }}{{ .BRANCH }}-{{ .SHA }}-{{ .TIMESTAMP }}{{ if .DIRTY }}-dirty{{ end }}{{ end }}{{end}}
+    vars:
+      TAG:
+        sh: git name-rev --name-only --tags --no-undefined HEAD 2>/dev/null | sed -n 's/^\([^^~]\{1,\}\)\(\^0\)\{0,1\}$/\1/p'
+      BRANCH:
+        sh: git rev-parse --abbrev-ref HEAD
+      DIRTY:
+        sh: git status --porcelain
+      SHA:
+        sh: git log --pretty=format:'%h' -n 1
+      TIMESTAMP:
+        sh: date +%s
 
   watch:
     desc: Watch fe and be file changes and rebuild
     dir: public
-    deps: ['deps:watch']
     cmds:
       - task: watch:fe
       - task: watch:be
@@ -122,13 +130,6 @@ tasks:
 
   release:
     cmds:
-        - |
-          cat <<HEREDOC > util/version.go
-          package util
-
-          var Version string = "{{ .VERSION }}"
-
-          HEREDOC
         - echo "Updating changelog:"
         - set +e
         - git changelog -t "v$VERSION"

--- a/public/html/admin.pug
+++ b/public/html/admin.pug
@@ -1,5 +1,5 @@
 .container-fluid
-	h1.text-center.no-top-margin semaphore v{{ semaphore.version }}
+	h1.text-center.no-top-margin semaphore {{ semaphore.version }}
 	hr
 	.row
 		.col-sm-4
@@ -11,7 +11,7 @@
 				li.list-group-item: a(href="https://ansible-semaphore.github.io/semaphore/" target="_blank") API Documentation
 		.col-sm-4
 			div(ng-if="upgrade.updateBody")
-				button.btn.btn-primary.btn-block(ng-click="doUpgrade()" ng-disabled="upgrade.config.cmdPath.length == 0") upgrade to {{ upgrade.update.tag_name }}
+				button.btn.btn-primary.btn-block(ng-click="doUpgrade()" ng-disabled="upgrade.config.cmdPath.length == 0") latest stable {{ upgrade.update.tag_name }}
 				p.text-center(ng-if="upgrade.config.cmdPath.length == 0")
 					a(href="https://github.com/ansible-semaphore/semaphore/wiki/Troubleshooting#upgrades-failing" target="_blank") Upgrading isn't possible!
 					br

--- a/public/html/index.pug
+++ b/public/html/index.pug
@@ -35,7 +35,7 @@ html(lang="en" ng-app="semaphore")
 							| &nbsp;
 						i.fa.fa-fw.fa-cog
 					ul(uib-dropdown-menu)
-						li.dropdown-header semaphore v{{ semaphore.version }}
+						li.dropdown-header semaphore {{ semaphore.version }}
 						li: a(ui-sref="admin")
 							span(ng-if="semaphore.update")
 								i.fa.fa-fw.fa-exclamation-circle

--- a/util/config.go
+++ b/util/config.go
@@ -93,10 +93,18 @@ func ConfigInit() {
 	var printConfig bool
 	flag.BoolVar(&printConfig, "printConfig", false, "print example configuration")
 
+	var printVersion bool
+	flag.BoolVar(&printVersion, "version", false, "print the semaphore version")
+
 	flag.Parse()
 
 	if InteractiveSetup {
 		return
+	}
+
+	if printVersion {
+		fmt.Println(Version)
+		os.Exit(0)
 	}
 
 	if printConfig {

--- a/util/version.go
+++ b/util/version.go
@@ -1,4 +1,0 @@
-package util
-
-var Version string = "2.4.1"
-

--- a/util/version_gen/generator.go
+++ b/util/version_gen/generator.go
@@ -1,0 +1,44 @@
+// +build ignore
+
+package main
+
+import (
+	"log"
+	"os"
+	"text/template"
+)
+
+var versionTmpl = `package util
+
+//The Semaphore build version
+var Version = "{{ .VERSION }}"
+`
+
+func main(){
+
+	if len(os.Args) <= 1 {
+		log.Fatalln("Must pass in version number")
+	}
+
+	data := make(map[string]string)
+	data["VERSION"] = os.Args[1]
+
+	tmpl := template.New("version")
+	var err error
+	if tmpl, err = tmpl.Parse(versionTmpl); err != nil {
+		log.Fatalln(err)
+	}
+
+	f, err := os.Create("util/version.go")
+	if err != nil {
+		log.Fatalln(err)
+	}
+	defer func(r *os.File) {
+		err = r.Close()
+		if err != nil {
+			log.Fatalln(err)
+		}
+	}(f)
+
+	tmpl.Execute(f, data)
+}


### PR DESCRIPTION
This is a proposal to replace the version.go file with a generated version, which is created at task compile time. This allows us to give every release of semaphore a unique ID by which we can identify it, which becomes more important once we start pushing out docker images for development builds, and it also makes it easier to identify what build you are actually running. It additionally adds the `--version` option to the semaphore cli, which will return the current version string and exit.

The version generator itself is really simple, it expects you to pass in a version string to it, and renders the file pretty much as before, therefore most of the actual logic happens in the taskfile to render a unique value. It uses the following logic:

If a tag exists on this commit then use it.
Else if the `SEMAPHORE_VERSION` variable is set use it
Else build an id using the following:
`{{ .BRANCH }}-{{ .SHA }}-{{ .TIMESTAMP }}{{ if .DIRTY }}-dirty{{ end }}`