### PR TITLE
fix port : prefix issues when building config data

### DIFF
--- a/util/config.go
+++ b/util/config.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/gorilla/securecookie"
 	"golang.org/x/crypto/bcrypt"
+	"strings"
 )
 
 var Cookie *securecookie.SecureCookie
@@ -134,21 +135,7 @@ func ConfigInit() {
 	}
 
 	loadConfig()
-
-	if len(os.Getenv("PORT")) > 0 {
-		Config.Port = ":" + os.Getenv("PORT")
-	}
-	if len(Config.Port) == 0 {
-		Config.Port = ":3000"
-	}
-
-	if len(Config.TmpPath) == 0 {
-		Config.TmpPath = "/tmp/semaphore"
-	}
-
-	if Config.MaxParallelTasks < 1 {
-		Config.MaxParallelTasks = 10
-	}
+	validateConfig()
 
 	var encryption []byte
 	encryption = nil
@@ -195,6 +182,34 @@ func loadConfig(){
 	fmt.Println("Using config file: "+ *confPath)
 
 }
+
+func validateConfig(){
+
+	validatePort()
+
+	if len(Config.TmpPath) == 0 {
+		Config.TmpPath = "/tmp/semaphore"
+	}
+
+	if Config.MaxParallelTasks < 1 {
+		Config.MaxParallelTasks = 10
+	}
+}
+
+func validatePort() {
+
+	//TODO - why do we do this only with this variable?
+	if len(os.Getenv("PORT")) > 0 {
+		Config.Port = ":" + os.Getenv("PORT")
+	}
+	if len(Config.Port) == 0 {
+		Config.Port = ":3000"
+	}
+	if !strings.HasPrefix(Config.Port, ":"){
+		Config.Port = ":"+Config.Port
+	}
+}
+
 
 
 func decodeConfig(file *os.File){

--- a/util/config_test.go
+++ b/util/config_test.go
@@ -1,0 +1,28 @@
+package util
+
+import (
+	"testing"
+	"os"
+)
+
+func TestValidatePort(t *testing.T){
+
+	Config = new(configType)
+	Config.Port = ""
+	validatePort()
+	if Config.Port != ":3000" {
+		t.Error("no port should get set to default")
+	}
+
+	Config.Port = "4000"
+	validatePort()
+	if Config.Port != ":4000" {
+		t.Error("Port without : suffix should have it added")
+	}
+
+	os.Setenv("PORT", "5000")
+	validatePort()
+	if Config.Port != ":5000" {
+		t.Error("Port value should be overwritten by env var, and it should be prefixed appropriately")
+	}
+}


### PR DESCRIPTION
fix for #401 which ensures that the config contains a port value which is always prefixed with `:`