### PR TITLE
skip goreleaser install on windows and warn

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -38,6 +38,8 @@ go get ./...
 go get -u github.com/go-task/task/cmd/task
 task deps
 ```
+Windows users will additionally need to manually install goreleaser from https://github.com/goreleaser/goreleaser/releases
+
 
 4) Set up config, database & run migrations
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,8 @@
 - [Releases](https://github.com/ansible-semaphore/semaphore/releases)
 - [Install Instructions](https://github.com/ansible-semaphore/semaphore/wiki/Installation)
 - [Troubleshooting](https://github.com/ansible-semaphore/semaphore/wiki/Troubleshooting)
-- [Roadmap](https://github.com/ansible-semaphore/semaphore/issues/325)
+- [Contribution Guide](https://github.com/ansible-semaphore/semaphore/blob/develop/CONTRIBUTING.md)
+- [Roadmap](https://github.com/ansible-semaphore/semaphore/projects)
 - [UI Walkthrough](https://blog.strangeman.info/ansible/2017/08/05/semaphore-ui-guide.html) (external blog)
 
 ## Contributing

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -36,15 +36,17 @@ tasks:
   deps:tools:
     desc: Installs tools needed
     dir: web
+    vars:
+      GORELEASER_VERSION: "0.62.5"
     cmds:
       - npm install -g nodemon
       - go get -u github.com/golang/dep/cmd/dep
       - go get github.com/cespare/reflex || true
       - go get -u github.com/gobuffalo/packr/...
       - go get -u github.com/haya14busa/goverage
-      # needs go 1.10+
-      - go get github.com/goreleaser/goreleaser/...
-
+      - '{{ if ne OS "windows" }} curl -L https://github.com/goreleaser/goreleaser/releases/download/v{{ .GORELEASER_VERSION }}/goreleaser_$(uname -s)_$(uname -m).tar.gz | tar -xz -C ${GOPATH}/bin{{ else }}ver>nul{{ end }}'
+      - '{{ if ne OS "windows" }} chmod +x ${GOPATH}/bin/goreleaser{{ else }}ver>nul{{ end }}'
+      - '{{ if eq OS "windows" }} echo "NOTICE: You must download goreleaser manually to build this application https://github.com/goreleaser/goreleaser/releases "{{ else }}:{{ end }}'
   compile:
     desc: Generates compiled frontend and backend resources (must be in this order)
     cmds:

--- a/circle.yml
+++ b/circle.yml
@@ -8,6 +8,7 @@ machine:
 dependencies:
   pre:
     - sudo apt-get install rpm
+    - mkdir -p ${GOPATH}/bin
     - rm -rf ${CPATH} && mkdir -p ${CPATH}
     - ln -sfn ${HOME}/${CIRCLE_PROJECT_REPONAME} ${CPATH}
     - sudo rm -rf /usr/local/go


### PR DESCRIPTION
Proposal to deal with goreleaser on windows and linux. See #498 for context.

As this is actually quite a difficult issue to solve in an elegant way and `go get` with and without `/...` causes issues on different versions of linux (current implementation breaking on cirleci and fedora) and windows this PR proposes that we instead curl the binary and install it to `$GOPATH/bin`.

As curl is not possible on windows we unfortunately skip these steps for windows users and instead echo a warning that they must install the tool manually. Additionally this manual step information has been added in the contribution guide.

Please can you check the goreleaser install steps are skipped properly on windows when reviewing.
@fiftin - any thought or input? Is there some one-liner we could use in windows to download and install the binary?