### PR TITLE
openshift template

### DIFF
--- a/deployment/openshift/README.md
+++ b/deployment/openshift/README.md
@@ -1,0 +1,27 @@
+# Deploying Semaphore on Openshift
+
+This is intended as a quick starter config to get semaphore up and running using only the docker hub image.The image is set to be periodically pulled from the repository source.
+
+## Setup
+
+Your openshift cluster needs to have the mysql-persistent template installed, however it comes by default.
+```
+# oc cluster up
+oc new-project semaphore
+oc create -fdeployment/openshift/template.yml
+oc new-app mysql-persistent -p MYSQL_DATABASE=semaphore
+oc new-app semaphore # -p SEMAPHORE_IMAGE_TAG=develop
+```
+
+It will take some moments for the application to become available (mainly due to the mysql pod startup time), check the logs of the semaphore container to see when it is ready. After this the web ui will be available on http://semaphore-semaphore.127.0.0.1.nip.io/auth/login (if running your oc cluster locally and you did not override the url via parameters). You can log in with the default values.
+If you deploy the template to multiple namespaces you must set the SEMAPHORE_URL to a unique value or it will be rejected by the router.
+
+## Parameters
+
+`oc process --parameters semaphore`
+
+|NAME| DESCRIPTION| VALUE|
+|SEMAPHORE_IMAGE_SOURCE| The id of the repository from which to pull the semaphore image| docker.io/ansiblesemaphore/semaphore|
+|SEMAPHORE_IMAGE_TAG| The tag to use for the semaphore repository| latest|
+|SEMAPHORE_DATA_VOLUME_SIZE| The size, in Gi of the semaphore data volume, which is mounted at /etc/semaphore| 5|
+|SEMAPHORE_URL| Set this to the value which you wish to be passed to the route. Default value works for local development usage| semaphore-semaphore.127.0.0.1.nip.io|

--- a/deployment/openshift/template.yml
+++ b/deployment/openshift/template.yml
@@ -1,0 +1,166 @@
+apiVersion: v1
+kind: Template
+metadata:
+  name: semaphore
+objects:
+- apiVersion: v1
+  kind: ImageStream
+  metadata:
+    name: semaphore
+    labels:
+      app: semaphore
+  spec:
+    tags:
+    - name: latest
+      from:
+        kind: DockerImage
+        name: "${SEMAPHORE_IMAGE_SOURCE}:${SEMAPHORE_IMAGE_TAG}"
+      importPolicy:
+        scheduled: true
+- apiVersion: v1
+  kind: PersistentVolumeClaim
+  metadata:
+    name: semaphore-data
+  spec:
+    accessModes:
+    - ReadWriteOnce
+    resources:
+      requests:
+        storage: "${SEMAPHORE_DATA_VOLUME_SIZE}Gi"
+  status: {}
+- apiVersion: v1
+  kind: DeploymentConfig
+  metadata:
+    labels:
+      app: semaphore
+    name: semaphore
+  spec:
+    replicas: 1
+    selector:
+      app: semaphore
+      deploymentconfig: semaphore
+    strategy:
+      activeDeadlineSeconds: 21600
+      resources: {}
+      rollingParams:
+        intervalSeconds: 1
+        maxSurge: 25%
+        maxUnavailable: 25%
+        timeoutSeconds: 600
+        updatePeriodSeconds: 1
+      type: Rolling
+    template:
+      metadata:
+        labels:
+          app: semaphore
+          deploymentconfig: semaphore
+      spec:
+        containers:
+        - env:
+          - name: SEMAPHORE_DB_HOST
+            value: mysql
+          - name: SEMAPHORE_DB
+            value: semaphore
+          - name: SEMAPHORE_DB_PASS
+            valueFrom:
+              secretKeyRef:
+                key: database-password
+                name: mysql
+          - name: SEMAPHORE_DB_USER
+            valueFrom:
+              secretKeyRef:
+                key: database-user
+                name: mysql
+          - name: SEMAPHORE_PLAYBOOK_PATH
+            value: /tmp/semaphore
+          imagePullPolicy: Always
+          name: semaphore
+          ports:
+          - containerPort: 3000
+            protocol: TCP
+          resources: {}
+          terminationMessagePath: /dev/termination-log
+          terminationMessagePolicy: File
+          volumeMounts:
+          - mountPath: /etc/semaphore
+            name: semaphore-etc
+            subPath: etc
+          - mountPath: /tmp
+            name: tmp
+        dnsPolicy: ClusterFirst
+        restartPolicy: Always
+        schedulerName: default-scheduler
+        securityContext: {}
+        terminationGracePeriodSeconds: 30
+        volumes:
+        - name: semaphore-etc
+          persistentVolumeClaim:
+            claimName: semaphore-data
+        - name: tmp
+          emptyDir:
+    test: false
+    triggers:
+    - type: ConfigChange
+    - imageChangeParams:
+        automatic: true
+        containerNames:
+        - semaphore
+        from:
+          kind: ImageStreamTag
+          name: semaphore:latest
+      type: ImageChange
+- apiVersion: v1
+  kind: Route
+  metadata:
+    name: semaphore
+  spec:
+    host: "${SEMAPHORE_URL}"
+    port:
+      targetPort: 3000-tcp
+    to:
+      kind: Service
+      name: semaphore
+      weight: 100
+    wildcardPolicy: None
+- apiVersion: v1
+  kind: Service
+  metadata:
+    labels:
+      app: semaphore
+    name: semaphore
+  spec:
+    ports:
+    - name: 3000-tcp
+      port: 3000
+      protocol: TCP
+      targetPort: 3000
+    selector:
+      app: semaphore
+      deploymentconfig: semaphore
+    sessionAffinity: None
+    type: ClusterIP
+  status:
+    loadBalancer: {}
+
+
+parameters:
+  - name: SEMAPHORE_IMAGE_SOURCE
+    displayName: Semaphore image
+    description: The id of the repository from which to pull the semaphore image
+    value: docker.io/ansiblesemaphore/semaphore
+    required: true
+  - name: SEMAPHORE_IMAGE_TAG
+    displayName: Semaphore image
+    description: The tag to use for the semaphore repository
+    value: latest
+    required: true
+  - name: SEMAPHORE_DATA_VOLUME_SIZE
+    displayName: Semaphore data volume size
+    description: The size, in Gi of the semaphore data volume, which is mounted at /etc/semaphore
+    value: "5"
+    required: true
+  - name: SEMAPHORE_URL
+    displayName: URL
+    description: Set this to the value which you wish to be passed to the route. If blank will use generated url
+    required: false
+


### PR DESCRIPTION
Working openshift template for semaphore deploys. Deleted the old PR as that branch was so far behind develop now.

Note that at the moment you will need to use the parameter ` -p SEMAPHORE_IMAGE_TAG=develop` or switch to the old repo when running `oc new-app semaphore` as we dont have a latest tag in the new repo yet.