### PR TITLE
pin mysql to 5.6

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -168,7 +168,7 @@ jobs:
   test:db:migration:
     docker:
       - *golang-image
-      - image: circleci/mysql
+      - image: circleci/mysql:5.6
     working_directory: *working-dir
     steps:
       - *install-task-binary

--- a/deployment/docker/ci/docker-compose.yml
+++ b/deployment/docker/ci/docker-compose.yml
@@ -2,7 +2,7 @@ version: '2'
 
 services:
   mysql:
-    image: mysql
+    image: mysql:5.6
     environment:
       MYSQL_RANDOM_ROOT_PASSWORD: 'yes'
       MYSQL_DATABASE: semaphore


### PR DESCRIPTION
pins mysql to 5.6 so that 8 is not chosen when testing as it results in breakage