### PR TITLE
Add function “Extra CLI Arguments”  in "Create Task UI”.

### DIFF
--- a/api/tasks/runner.go
+++ b/api/tasks/runner.go
@@ -444,9 +444,18 @@ func (t *task) getPlaybookArgs() ([]string, error) {
 		args = append(args, "--extra-vars", extraVar)
 	}
 
-	var extraArgs []string
+	var templateExtraArgs []string
 	if t.template.Arguments != nil {
-		err := json.Unmarshal([]byte(*t.template.Arguments), &extraArgs)
+		err := json.Unmarshal([]byte(*t.template.Arguments), &templateExtraArgs)
+		if err != nil {
+			t.log("Could not unmarshal arguments to []string")
+			return nil, err
+		}
+	}
+
+	var taskExtraArgs []string
+	if t.task.Arguments != nil {
+		err := json.Unmarshal([]byte(*t.task.Arguments), &taskExtraArgs)
 		if err != nil {
 			t.log("Could not unmarshal arguments to []string")
 			return nil, err
@@ -454,9 +463,10 @@ func (t *task) getPlaybookArgs() ([]string, error) {
 	}
 
 	if t.template.OverrideArguments {
-		args = extraArgs
+		args = templateExtraArgs
 	} else {
-		args = append(args, extraArgs...)
+		args = append(args, templateExtraArgs...)
+		args = append(args, taskExtraArgs...)
 		args = append(args, playbookName)
 	}
 	return args, nil

--- a/db/Task.go
+++ b/db/Task.go
@@ -2,7 +2,6 @@ package db
 
 import "time"
 
-
 //Task is a model of a task which will be executed by the runner
 type Task struct {
 	ID         int `db:"id" json:"id"`
@@ -16,6 +15,8 @@ type Task struct {
 	// override variables
 	Playbook    string `db:"playbook" json:"playbook"`
 	Environment string `db:"environment" json:"environment"`
+	// to fit into []string
+	Arguments *string `db:"arguments" json:"arguments"`
 
 	UserID *int `db:"user_id" json:"user_id"`
 

--- a/db/migrations/v2.5.2.sql
+++ b/db/migrations/v2.5.2.sql
@@ -1,0 +1,1 @@
+alter table task add `arguments` text null;

--- a/db/version.go
+++ b/db/version.go
@@ -82,5 +82,6 @@ func init() {
 		{Major: 2, Minor: 3, Patch: 2},
 		{Major: 2, Minor: 4},
 		{Major: 2, Minor: 5},
+		{Major: 2, Minor: 5, Patch: 2},
 	}
 }

--- a/web/resources/pug/projects/createTaskModal.pug
+++ b/web/resources/pug/projects/createTaskModal.pug
@@ -14,6 +14,10 @@
 			.col-sm-6
 				div(ui-ace="{mode: 'json', workerPath: '/public/js/ace/'}" class="form-control" style="height: 100px" ng-model="task.environment")
 		.form-group
+			label.control-label.col-sm-4(uib-tooltip='*MUST* be a JSON array! Each argument must be an element of the array, for example: ["-i", "@myinventory.sh", "--private-key=/there/id_rsa", "-vvvv"]') Extra CLI Arguments
+			.col-sm-6
+				div(ui-ace="{mode: 'json', workerPath: '/public/js/ace/'}" style="height: 100px" class="form-control" ng-model="task.arguments")
+		.form-group
 			.col-sm-6.col-sm-offset-4: .checkbox: label
 				input(type="checkbox" ng-model="task.debug")
 				| Debug (<code>-vvvv</code>)


### PR DESCRIPTION
Hello I'm newbie :)

I needed to additional arguments field in task launch process that is after clicking on Run button. It is very useful for us to be able to add extra arguments just before execution.

So I add “Extra CLI Arguments” filed to “Create Task” UI. 

![semaphore_args](https://user-images.githubusercontent.com/16604419/45362133-f28e2780-b60e-11e8-97a3-1f410d32d081.png)


And I added the following tasks to make the process work.
- Added "Extra CLI Arguments" filed to "Create Task" UI.
- Added arguments column on "task" table for adding arguments inserted by "Create Task" UI.
- Added "task.arguments" value to getPlaybookArgs () method for append the value to command's arguments.