### PR TITLE
Set version on windows taskfile

### DIFF
--- a/Taskfile_windows.yml
+++ b/Taskfile_windows.yml
@@ -1,3 +1,4 @@
+version: '2'
 tasks:
   compile:be:
     cmds:


### PR DESCRIPTION
It doesn't otherwise build on windows since by default it's `1`: 
```powershell
Taskfiles versions should match. First is "2" but second is "1"
```