### PR TITLE
Fix goreleaser arm64 rpm and update to v0.159.0

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -2,9 +2,6 @@
 # for building binaries and packages for distributions and releasing on github
 dist: bin
 
-git:
-  short_hash: true
-
 builds:
   - binary: semaphore
     main: ./cli/main.go
@@ -26,45 +23,48 @@ builds:
     hooks:
       pre: task compile
 
-archive:
-  format_overrides:
-    - goos: windows
-      format: zip
-  files:
-    - LICENSE
+archives:
+  -
+    format_overrides:
+      - goos: windows
+        format: zip
+    files:
+      - LICENSE
 
-sign:
-   artifacts: checksum
-   # gpg --sign -u "8CDE D132 5E96 F1D9 EABF 17D4 2C96 CF7D D27F AB82" --pinentry-mode loopback --yes --batch --passphrase "${GPG_PASS}" --output ${signature} --detach-sign "${artifact}"
-   args: ["-u", "8CDE D132 5E96 F1D9 EABF 17D4 2C96 CF7D D27F AB82", "--pinentry-mode", "loopback", "--yes", "--batch", "--output", "${signature}", "--detach-sign", "${artifact}"]
+signs:
+  -
+    artifacts: checksum
+    # gpg --sign -u "8CDE D132 5E96 F1D9 EABF 17D4 2C96 CF7D D27F AB82" --pinentry-mode loopback --yes --batch --passphrase "${GPG_PASS}" --output ${signature} --detach-sign "${artifact}"
+    args: ["-u", "8CDE D132 5E96 F1D9 EABF 17D4 2C96 CF7D D27F AB82", "--pinentry-mode", "loopback", "--yes", "--batch", "--output", "${signature}", "--detach-sign", "${artifact}"]
 
 # Start the snapshot name with a numerical value
 # so it does not need to be force installed
 snapshot:
-  name_template: "{{ .Timestamp }}-{{ .Commit }}-SNAPSHOT"
+  name_template: "{{ .Timestamp }}-{{ .ShortCommit }}-SNAPSHOT"
 
-nfpm:
-  name_template: "{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}"
+nfpms:
+  - 
+    file_name_template: "{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}"
 
-  vendor: Castaway Consulting LLC
-  homepage: https://github.com/ansible-semaphore/semaphore
-  maintainer: Castaway Consulting LLC <support@castawaylabs.com>
-  description: Open Source alternative to Ansible Tower
-  license: MIT
+    vendor: Castaway Consulting LLC
+    homepage: https://github.com/ansible-semaphore/semaphore
+    maintainer: Castaway Consulting LLC <support@castawaylabs.com>
+    description: Open Source alternative to Ansible Tower
+    license: MIT
 
-  formats:
-    - deb
-    - rpm
+    formats:
+      - deb
+      - rpm
 
-  # Packages your package depends on.
-  dependencies:
-    - git
+    # Packages your package depends on.
+    dependencies:
+      - git
 
-  suggests:
-    - ansible
+    suggests:
+      - ansible
 
-  # install binary in /usr/bin
-  bindir: /usr/bin
+    # install binary in /usr/bin
+    bindir: /usr/bin
 
 release:
   # Do not auto publish release

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -58,7 +58,7 @@ tasks:
     desc: Installs tools needed
     dir: web
     vars:
-      GORELEASER_VERSION: "0.67.0"
+      GORELEASER_VERSION: "0.159.0"
       GOLINTER_VERSION: "1.31.0"
     cmds:
       - go install github.com/cespare/reflex


### PR DESCRIPTION
This fixes https://github.com/ansible-semaphore/semaphore/issues/648
The issue why arm64 rpms dont work on aarch64 is likely an outdated version of goreleaser(https://github.com/goreleaser/nfpm/issues/311).
I pulled it up and changed the configuration so it works with the new goreleaser version. However i tested just with "gorelease check" for the config syntax. I was not able to build since i am missing a lot of build tools and couldt get it to work even when downloading all of them (vue-cli,packr,nodejs+packages etc.)

So take it with a grain of salt, though all thats changed is goreleaser version and the config change is pure syntactical based on https://goreleaser.com/deprecations/ 

