### PR TITLE
Change galaxy run behaviour

### DIFF
--- a/api/helpers/helpers.go
+++ b/api/helpers/helpers.go
@@ -1,14 +1,20 @@
 package helpers
 
 import (
+	"crypto/md5"
 	"encoding/json"
-	log "github.com/Sirupsen/logrus"
-	"github.com/ansible-semaphore/semaphore/db"
-	"github.com/gorilla/context"
+	"fmt"
+	"io"
 	"net/http"
+	"os"
 	"runtime/debug"
 	"strconv"
 	"strings"
+
+	log "github.com/Sirupsen/logrus"
+	"github.com/gorilla/context"
+
+	"github.com/ansible-semaphore/semaphore/db"
 
 	"github.com/gorilla/mux"
 )
@@ -63,7 +69,6 @@ func WriteJSON(w http.ResponseWriter, code int, out interface{}) {
 	}
 }
 
-
 func WriteError(w http.ResponseWriter, err error) {
 	if err == db.ErrNotFound {
 		w.WriteHeader(http.StatusNotFound)
@@ -74,3 +79,18 @@ func WriteError(w http.ResponseWriter, err error) {
 	debug.PrintStack()
 	w.WriteHeader(http.StatusInternalServerError)
 }
+
+func GetMD5Hash(filepath string) (string, error) {
+	file, err := os.Open(filepath)
+	if err != nil {
+		return "", err
+	}
+	defer file.Close()
+
+	hash := md5.New()
+	if _, err := io.Copy(hash, file); err != nil {
+		return "", err
+	}
+	return fmt.Sprintf("%x", hash.Sum(nil)), nil
+}
+

--- a/api/tasks/runner.go
+++ b/api/tasks/runner.go
@@ -551,6 +551,15 @@ func hasRequirementsChanges(requirementsFilePath string, requirementsHashFilePat
 	return string(oldFileMD5HashBytes) != newFileMD5Hash
 }
 
+func writeMD5Hash(requirementsFile string, requirementsHashFile string) error {
+	newFileMD5Hash, err := helpers.GetMD5Hash(requirementsFile)
+	if err != nil {
+		return err
+	}
+
+	return ioutil.WriteFile(requirementsHashFile, []byte(newFileMD5Hash), 0644)
+}
+
 // extractCommandEnvironment unmarshalls a json string, extracts the ENV key from it and returns it as
 // []string where strings are in key=value format
 func extractCommandEnvironment(envJSON string) []string {

--- a/api/tasks/runner.go
+++ b/api/tasks/runner.go
@@ -368,7 +368,7 @@ func (t *task) installRequirements() error {
 	requirementsHashFilePath := fmt.Sprintf("%s/repository_%d/requirements.md5", util.Config.TmpPath, t.repository.ID)
 
 	if _, err := os.Stat(requirementsFilePath); err != nil {
-		t.log("No requirements.yml found in roles directory\n")
+		t.log("No roles/requirements.yml file found. Skip galaxy install process.\n")
 		return nil
 	}
 

--- a/api/tasks/runner.go
+++ b/api/tasks/runner.go
@@ -537,6 +537,20 @@ func (t *task) envVars(home string, pwd string, gitSSHCommand *string) []string 
 	return env
 }
 
+func hasRequirementsChanges(requirementsFilePath string, requirementsHashFilePath string) bool {
+	oldFileMD5HashBytes, err := ioutil.ReadFile(requirementsHashFilePath)
+	if err != nil {
+		return true
+	}
+
+	newFileMD5Hash, err := helpers.GetMD5Hash(requirementsFilePath)
+	if err != nil {
+		return true
+	}
+
+	return string(oldFileMD5HashBytes) != newFileMD5Hash
+}
+
 // extractCommandEnvironment unmarshalls a json string, extracts the ENV key from it and returns it as
 // []string where strings are in key=value format
 func extractCommandEnvironment(envJSON string) []string {

--- a/api/tasks/runner.go
+++ b/api/tasks/runner.go
@@ -119,29 +119,8 @@ func (t *task) prepareRun() {
 		return
 	}
 
-	if err := t.runGalaxy([]string{
-		"install",
-		"-r",
-		"roles/requirements.yml",
-		"-p",
-		"./roles/",
-		"--force",
-	}); err != nil {
+	if err := t.installRequirements(); err != nil {
 		t.log("Running galaxy failed: " + err.Error())
-		t.fail()
-		return
-	}
-
-	if err := t.runGalaxy([]string{
-		"collection",
-		"install",
-		"-r",
-		"roles/requirements.yml",
-		"-p",
-		"./roles/",
-		"--force",
-	}); err != nil {
-		t.log("Running galaxy collection failed: " + err.Error())
 		t.fail()
 		return
 	}
@@ -379,6 +358,30 @@ func (t *task) updateRepository() error {
 
 	t.logCmd(cmd)
 	return cmd.Run()
+}
+
+func (t *task) installRequirements() error {
+	if err := t.runGalaxy([]string{
+		"install",
+		"-r",
+		"roles/requirements.yml",
+		"-p",
+		"./roles/",
+		"--force",
+	}); err != nil {
+		return err
+	}
+
+	if err := t.runGalaxy([]string{
+		"collection",
+		"install",
+		"-r",
+		"roles/requirements.yml",
+		"--force",
+	}); err != nil {
+		return err
+	}
+	return nil
 }
 
 func (t *task) runGalaxy(args []string) error {

--- a/api/tasks/runner.go
+++ b/api/tasks/runner.go
@@ -6,7 +6,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"github.com/ansible-semaphore/semaphore/db"
 	"io/ioutil"
 	"os"
 	"os/exec"
@@ -15,7 +14,11 @@ import (
 	"strings"
 	"time"
 
+	"github.com/ansible-semaphore/semaphore/api/helpers"
+	"github.com/ansible-semaphore/semaphore/db"
+
 	log "github.com/Sirupsen/logrus"
+
 	"github.com/ansible-semaphore/semaphore/util"
 )
 

--- a/api/tasks/runner.go
+++ b/api/tasks/runner.go
@@ -361,6 +361,12 @@ func (t *task) updateRepository() error {
 }
 
 func (t *task) installRequirements() error {
+	requirementsFilePath := fmt.Sprintf("%s/repository_%d/roles/requirements.yml", util.Config.TmpPath, t.repository.ID)
+	if _, err := os.Stat(requirementsFilePath); err != nil {
+		t.log("No requirements.yml found in roles directory\n")
+		return nil
+	}
+
 	if err := t.runGalaxy([]string{
 		"install",
 		"-r",
@@ -390,10 +396,6 @@ func (t *task) runGalaxy(args []string) error {
 
 	gitSSHCommand := "ssh -o StrictHostKeyChecking=no -i " + t.repository.SSHKey.GetPath()
 	cmd.Env = t.envVars(util.Config.TmpPath, cmd.Dir, &gitSSHCommand)
-
-	if _, err := os.Stat(cmd.Dir + "/roles/requirements.yml"); err != nil {
-		return nil
-	}
 
 	t.logCmd(cmd)
 	return cmd.Run()


### PR DESCRIPTION
Changes: 
Galaxy run is only executed, if changes where made to the requirements.yml file in the roles directory and for the first run this updated is implemented.

I removed the -p parameter for the run, where you can specify a roles path, then the ansible.cfg will not be ignored. This is the normal behaviour, if you execute ansible galaxy without specifying a roles or collection dir. 
