### PR TITLE
docker: bump alpine from 3.13 -> 3.15

### DIFF
--- a/deployment/docker/ci/Dockerfile
+++ b/deployment/docker/ci/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.16.3-alpine3.13
+FROM golang:1.18.2-alpine3.15
 
 ENV SEMAPHORE_VERSION="development" SEMAPHORE_ARCH="linux_amd64" \
     SEMAPHORE_CONFIG_PATH="${SEMAPHORE_CONFIG_PATH:-/etc/semaphore}" \

--- a/deployment/docker/ci/dredd.Dockerfile
+++ b/deployment/docker/ci/dredd.Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.16.3-alpine3.13 as golang
+FROM golang:1.18.2-alpine3.15 as golang
 
 RUN apk add --no-cache curl git
 

--- a/deployment/docker/dev/Dockerfile
+++ b/deployment/docker/dev/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.16.3-alpine3.13
+FROM golang:1.18.2-alpine3.15
 
 ENV SEMAPHORE_VERSION="development" SEMAPHORE_ARCH="linux_amd64" \
     SEMAPHORE_CONFIG_PATH="${SEMAPHORE_CONFIG_PATH:-/etc/semaphore}" \

--- a/deployment/docker/dev/dredd.Dockerfile
+++ b/deployment/docker/dev/dredd.Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.16.3-alpine3.13 as golang
+FROM golang:1.18.2-alpine3.15 as golang
 
 RUN apk add --no-cache curl git
 

--- a/deployment/docker/prod/Dockerfile
+++ b/deployment/docker/prod/Dockerfile
@@ -1,5 +1,5 @@
 # ansible-semaphore production image
-FROM golang:1.16.3-alpine3.13 as builder
+FROM golang:1.18.2-alpine3.15 as builder
 
 LABEL maintainer="Tom Whiston <tom.whiston@gmail.com>"
 
@@ -11,7 +11,7 @@ RUN apk add --no-cache -U libc-dev curl nodejs npm git && \
 
 # Uses frolvlad alpine so we have access to glibc which is needed for golang
 # and when deploying in openshift
-FROM frolvlad/alpine-glibc:alpine-3.13 as runner
+FROM frolvlad/alpine-glibc:alpine-3.15 as runner
 
 RUN apk add --no-cache sshpass git curl ansible mysql-client openssh-client tini && \
     adduser -D -u 1001 -G root semaphore && \


### PR DESCRIPTION
How do you feel about bumping the golang and Alpine versions? Having access to a newer Alpine makes it simpler to add Ansible dependencies to Semaphore containers as I brought up in #933 and this would help with being able to concisely extend the Semaphore containers.