### PR TITLE
upgrade frolvlad/alpine-glibc to alpine-3.16

### DIFF
--- a/deployment/docker/prod/Dockerfile
+++ b/deployment/docker/prod/Dockerfile
@@ -1,7 +1,6 @@
 # ansible-semaphore production image
 FROM golang:1.18.3-alpine3.16 as builder
 
-LABEL maintainer="Tom Whiston <tom.whiston@gmail.com>"
 
 COPY ./ /go/src/github.com/ansible-semaphore/semaphore
 WORKDIR /go/src/github.com/ansible-semaphore/semaphore
@@ -11,7 +10,8 @@ RUN apk add --no-cache -U libc-dev curl nodejs npm git && \
 
 # Uses frolvlad alpine so we have access to glibc which is needed for golang
 # and when deploying in openshift
-FROM frolvlad/alpine-glibc:alpine-3.13 as runner
+FROM frolvlad/alpine-glibc:alpine-3.16 as runner
+LABEL maintainer="Tom Whiston <tom.whiston@gmail.com>"
 
 RUN apk add --no-cache sshpass git curl ansible mysql-client openssh-client tini && \
     adduser -D -u 1001 -G root semaphore && \


### PR DESCRIPTION
This PR updates the base image for the productive image also to alpine-3.16 and uses the same alpine version that is used for the build

also the maintainer label is moved in the productive image. in the builder image it's of no use