### PR TITLE
remove black color from buttons to get theme default

### DIFF
--- a/web2/src/components/TaskLink.vue
+++ b/web2/src/components/TaskLink.vue
@@ -10,7 +10,6 @@
     <span v-if="disabled">{{ label }}</span>
     <v-tooltip
         v-else
-        color="black"
         right
         max-width="350"
         transition="fade-transition"

--- a/web2/src/components/TaskList.vue
+++ b/web2/src/components/TaskList.vue
@@ -67,7 +67,7 @@
       </template>
 
       <template v-slot:item.actions="{ item }">
-        <v-btn text color="black" class="pl-1 pr-2" @click="createTask(item)">
+        <v-btn text class="pl-1 pr-2" @click="createTask(item)">
           <v-icon class="pr-1">mdi-replay</v-icon>
           Re{{ getActionButtonTitle() }}
         </v-btn>

--- a/web2/src/views/project/TemplateView.vue
+++ b/web2/src/views/project/TemplateView.vue
@@ -86,7 +86,6 @@
 
       <v-btn
         icon
-        color="black"
         @click="copyDialog = true"
       >
         <v-icon>mdi-content-copy</v-icon>
@@ -94,7 +93,6 @@
 
       <v-btn
         icon
-        color="black"
         @click="editDialog = true"
       >
         <v-icon>mdi-pencil</v-icon>

--- a/web2/src/views/project/Templates.vue
+++ b/web2/src/views/project/Templates.vue
@@ -197,7 +197,7 @@
       </template>
 
       <template v-slot:item.actions="{ item }">
-        <v-btn text color="black" class="pl-1 pr-2" @click="createTask(item.id)">
+        <v-btn text class="pl-1 pr-2" @click="createTask(item.id)">
           <v-icon class="pr-1">mdi-replay</v-icon>
           {{ TEMPLATE_TYPE_ACTION_TITLES[item.type] }}
         </v-btn>


### PR DESCRIPTION
In this PR the black color is removed from buttons to get the theme's default color.
Whit this applied, the button text changes to white in dark mode.