### PR TITLE
Add py3-aiohttp

### DIFF
--- a/deployment/docker/prod/Dockerfile
+++ b/deployment/docker/prod/Dockerfile
@@ -13,7 +13,7 @@ RUN apk add --no-cache -U libc-dev curl nodejs npm git && \
 FROM frolvlad/alpine-glibc:alpine-3.16 as runner
 LABEL maintainer="Tom Whiston <tom.whiston@gmail.com>"
 
-RUN apk add --no-cache sshpass git curl ansible mysql-client openssh-client-default tini && \
+RUN apk add --no-cache sshpass git curl ansible mysql-client openssh-client-default tini py3-aiohttp && \
     adduser -D -u 1001 -G root semaphore && \
     mkdir -p /tmp/semaphore && \
     mkdir -p /etc/semaphore && \


### PR DESCRIPTION
Add py3-aiohttp which is used by vmware.vmware_rest.vcenter_vm (if specified in requirements.yml).
There appears to be no way to add python packages to the docker image, so I'm optimistic we can add this one since it is very common.

Since there is no `pip` either, we can't even add the package with `pip install --user aiohttp`.
Optimistic that we can add this simple/lightweight python library which is used by a few components.