### PR TITLE
Remove multiple tasks on same template restriction

### DIFF
--- a/services/tasks/pool.go
+++ b/services/tasks/pool.go
@@ -155,19 +155,12 @@ func (p *TaskPool) Run() {
 }
 
 func (p *TaskPool) blocks(t *TaskRunner) bool {
-
 	if len(p.runningTasks) >= util.Config.MaxParallelTasks {
 		return true
 	}
 
 	if p.activeProj[t.task.ProjectID] == nil || len(p.activeProj[t.task.ProjectID]) == 0 {
 		return false
-	}
-
-	for _, r := range p.activeProj[t.task.ProjectID] {
-		if r.template.ID == t.task.TemplateID {
-			return true
-		}
 	}
 
 	proj, err := p.store.GetProject(t.task.ProjectID)


### PR DESCRIPTION
Executing the same task template in parallel is very useful in lots of use cases. I don't know why it was restricted?