### PR TITLE
Update docker compose example in README.md to prevent data loss

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,9 @@ services:
       SEMAPHORE_ADMIN_NAME: admin
       SEMAPHORE_ADMIN_EMAIL: admin@localhost
       SEMAPHORE_ADMIN: admin
+    volumes:
+      - /path/to/data/home:/etc/semaphore # config.json location
+      - /path/to/data/lib:/var/lib/semaphore # database.boltdb location (Not required if using mysql or postgres)
 ```
 https://hub.docker.com/r/semaphoreui/semaphore
 


### PR DESCRIPTION
LOVE having a slim example of how to get started with semaphore + boltdb in the readme. Really lowers the barrier to entry / adoption.

However, the current example will result in data loss since it does not include a volume section to persist important data on the host. When the container is re-created the boltdb and config.json will be lost.

I have added some example volume mappings for those locations in the vein of linuxserver.io and many others on docker hub ([nginx example](https://hub.docker.com/r/linuxserver/nginx)).

I know some things can also be stored in /home/sempahore but I don't believe that's critical, irrecoverable info. Correct me if I'm wrong.