### PR TITLE
fix(runner): load {roles,collections} requirements files from repo root like AWX #1068

### DIFF
--- a/services/tasks/runner.go
+++ b/services/tasks/runner.go
@@ -502,7 +502,7 @@ func (t *TaskRunner) updateRepository() error {
 }
 
 func (t *TaskRunner) installCollectionsRequirements() error {
-	requirementsFilePath := path.Join(t.getPlaybookDir(), "collections", "requirements.yml")
+	requirementsFilePath := path.Join(t.getRepoPath(), "collections", "requirements.yml")
 	requirementsHashFilePath := fmt.Sprintf("%s.md5", requirementsFilePath)
 
 	if _, err := os.Stat(requirementsFilePath); err != nil {
@@ -531,7 +531,7 @@ func (t *TaskRunner) installCollectionsRequirements() error {
 }
 
 func (t *TaskRunner) installRolesRequirements() error {
-	requirementsFilePath := fmt.Sprintf("%s/roles/requirements.yml", t.getRepoPath())
+	requirementsFilePath := path.Join(t.getRepoPath(), "roles", "requirements.yml")
 	requirementsHashFilePath := fmt.Sprintf("%s.md5", requirementsFilePath)
 
 	if _, err := os.Stat(requirementsFilePath); err != nil {


### PR DESCRIPTION
Got bitten by the differences highlighted https://github.com/ansible-semaphore/semaphore/issues/1068#issuecomment-1303042950.

I know this isn't AWX, but following a similar expected structure may help with adoption by both AWX users and anyone with too many playbooks to keep them in the root of the repository.

This could technically be a breaking change for some users depending on their repository structured. I'm not sure if you would prefer to consider supporting multiple requirements files to support both AWX path logic and the existing logic.