### PR TITLE
Don't `--force` install collections

### DIFF
--- a/services/tasks/runner.go
+++ b/services/tasks/runner.go
@@ -519,7 +519,6 @@ func (t *TaskRunner) installCollectionsRequirements() error {
 			"install",
 			"-r",
 			requirementsFilePath,
-			"--force",
 		}); err != nil {
 			return err
 		}


### PR DESCRIPTION
If we already have the referenced collections/roles then there is no need to re-download them. If users require specific versions this can be specified in the associated requirements files which would trigger a download as needed.