### PR TITLE
Add py3-netaddr library to support copying templates between nodes

### DIFF
--- a/deployment/docker/prod/Dockerfile
+++ b/deployment/docker/prod/Dockerfile
@@ -10,7 +10,7 @@ RUN apk add --no-cache -U libc-dev curl nodejs npm git gcc g++ && \
 FROM alpine:3.16 as runner
 LABEL maintainer="Tom Whiston <tom.whiston@gmail.com>"
 
-RUN apk add --no-cache sshpass git curl ansible mysql-client openssh-client-default tini py3-aiohttp && \
+RUN apk add --no-cache sshpass git curl ansible mysql-client openssh-client-default tini py3-aiohttp py3-netaddr && \
     adduser -D -u 1001 -G root semaphore && \
     mkdir -p /tmp/semaphore && \
     mkdir -p /etc/semaphore && \

--- a/deployment/docker/prod/buildx.Dockerfile
+++ b/deployment/docker/prod/buildx.Dockerfile
@@ -13,7 +13,7 @@ RUN ./deployment/docker/prod/bin/install ${TARGETOS} ${TARGETARCH}
 FROM alpine:3.16 as runner
 LABEL maintainer="Tom Whiston <tom.whiston@gmail.com>"
 
-RUN apk add --no-cache sshpass git curl ansible mysql-client openssh-client-default tini py3-aiohttp && \
+RUN apk add --no-cache sshpass git curl ansible mysql-client openssh-client-default tini py3-aiohttp py3-netaddr && \
     adduser -D -u 1001 -G root semaphore && \
     mkdir -p /tmp/semaphore && \
     mkdir -p /etc/semaphore && \


### PR DESCRIPTION
The main reason for this PR is installing the py3-netaddr python library to support copying templates between two or more nodes. I found this because running a k3s playbook to install a k3s cluster.

![image](https://github.com/ansible-semaphore/semaphore/assets/152518/4038a544-9920-402b-9c9e-eb713ac100ca)

After installs the python library via container cmd:

![image](https://github.com/ansible-semaphore/semaphore/assets/152518/15563800-6854-495a-89c8-22abcf7b2ec5)
