### PR TITLE
feat(enhancement): use system dark mode

### DIFF
--- a/web/src/App.vue
+++ b/web/src/App.vue
@@ -853,8 +853,7 @@ import RestoreProjectForm from '@/components/RestoreProjectForm.vue';
 import YesNoDialog from '@/components/YesNoDialog.vue';
 import TaskLogDialog from '@/components/TaskLogDialog.vue';
 import delay from '@/lib/delay';
-
-const prefersDarkMode = window.matchMedia('(prefers-color-scheme: dark)');
+import darkModeMixin from '@/lib/darkMode';
 
 const PROJECT_COLORS = ['red', 'blue', 'orange', 'green'];
 
@@ -925,6 +924,7 @@ function getSystemLang() {
 
 export default {
   name: 'App',
+  mixins: [darkModeMixin],
   components: {
     SubscriptionForm,
     TaskLogDialog,
@@ -1005,17 +1005,6 @@ export default {
         EventBus.$emit('i-new-project', { projectType: this.$route.query.new_project });
       }
     },
-
-    darkMode(val) {
-      this.$vuetify.theme.dark = val;
-      if (val && !prefersDarkMode.matches) {
-        localStorage.setItem('darkMode', '1');
-      } else if (!val && prefersDarkMode.matches) {
-        localStorage.setItem('darkMode', '0');
-      } else {
-        localStorage.removeItem('darkMode');
-      }
-    },
   },
 
   computed: {
@@ -1057,19 +1046,7 @@ export default {
   },
 
   async created() {
-    const isDarkMode = localStorage.getItem('darkMode');
-    if (isDarkMode !== null) {
-      this.darkMode = isDarkMode === '1';
-    } else {
-      this.darkModeListener = (e) => {
-        this.darkMode = e.matches;
-      };
-      prefersDarkMode.addEventListener('change', this.darkModeListener);
-
-      if (prefersDarkMode.matches) {
-        this.darkMode = true;
-      }
-    }
+    this.initDarkMode();
 
     try {
       await this.loadData();
@@ -1222,12 +1199,6 @@ export default {
           break;
       }
     });
-  },
-
-  beforeDestroy() {
-    if (this.darkModeListener) {
-      prefersDarkMode.removeEventListener('change', this.darkModeListener);
-    }
   },
 
   methods: {

--- a/web/src/App.vue
+++ b/web/src/App.vue
@@ -1061,11 +1061,12 @@ export default {
     if (isDarkMode !== null) {
       this.darkMode = isDarkMode === '1';
     } else {
-      prefersDarkMode.addEventListener('change', (e) => {
+      this.darkModeListener = (e) => {
         this.darkMode = e.matches;
-      });
+      };
+      prefersDarkMode.addEventListener('change', this.darkModeListener);
 
-      if (prefersDarkMode.matches && localStorage.getItem('darkMode') !== '0') {
+      if (prefersDarkMode.matches) {
         this.darkMode = true;
       }
     }
@@ -1221,6 +1222,12 @@ export default {
           break;
       }
     });
+  },
+
+  beforeDestroy() {
+    if (this.darkModeListener) {
+      prefersDarkMode.removeEventListener('change', this.darkModeListener);
+    }
   },
 
   methods: {

--- a/web/src/App.vue
+++ b/web/src/App.vue
@@ -854,6 +854,8 @@ import YesNoDialog from '@/components/YesNoDialog.vue';
 import TaskLogDialog from '@/components/TaskLogDialog.vue';
 import delay from '@/lib/delay';
 
+const prefersDarkMode = window.matchMedia('(prefers-color-scheme: dark)');
+
 const PROJECT_COLORS = ['red', 'blue', 'orange', 'green'];
 
 const LANGUAGES = {
@@ -1006,8 +1008,10 @@ export default {
 
     darkMode(val) {
       this.$vuetify.theme.dark = val;
-      if (val) {
+      if (val && !prefersDarkMode.matches) {
         localStorage.setItem('darkMode', '1');
+      } else if (!val && prefersDarkMode.matches) {
+        localStorage.setItem('darkMode', '0');
       } else {
         localStorage.removeItem('darkMode');
       }
@@ -1053,8 +1057,17 @@ export default {
   },
 
   async created() {
-    if (localStorage.getItem('darkMode') === '1') {
-      this.darkMode = true;
+    const isDarkMode = localStorage.getItem('darkMode');
+    if (isDarkMode !== null) {
+      this.darkMode = isDarkMode === '1';
+    } else {
+      prefersDarkMode.addEventListener('change', (e) => {
+        this.darkMode = e.matches;
+      });
+
+      if (prefersDarkMode.matches && localStorage.getItem('darkMode') !== '0') {
+        this.darkMode = true;
+      }
     }
 
     try {

--- a/web/src/lib/darkMode.js
+++ b/web/src/lib/darkMode.js
@@ -1,0 +1,46 @@
+const prefersDarkMode = window.matchMedia('(prefers-color-scheme: dark)');
+
+export default {
+  data() {
+    return {
+      darkModeListener: null,
+    };
+  },
+
+  watch: {
+    darkMode(val) {
+      this.$vuetify.theme.dark = val;
+      if (val && !prefersDarkMode.matches) {
+        localStorage.setItem('darkMode', '1');
+      } else if (!val && prefersDarkMode.matches) {
+        localStorage.setItem('darkMode', '0');
+      } else {
+        localStorage.removeItem('darkMode');
+      }
+    },
+  },
+
+  methods: {
+    initDarkMode() {
+      const isDarkMode = localStorage.getItem('darkMode');
+      if (isDarkMode !== null) {
+        this.darkMode = isDarkMode === '1';
+      } else {
+        this.darkModeListener = (e) => {
+          this.darkMode = e.matches;
+        };
+        prefersDarkMode.addEventListener('change', this.darkModeListener);
+
+        if (prefersDarkMode.matches) {
+          this.darkMode = true;
+        }
+      }
+    },
+  },
+
+  beforeDestroy() {
+    if (this.darkModeListener) {
+      prefersDarkMode.removeEventListener('change', this.darkModeListener);
+    }
+  },
+};

--- a/web/src/views/Auth.vue
+++ b/web/src/views/Auth.vue
@@ -336,10 +336,10 @@
 import axios from 'axios';
 import { getErrorMessage } from '@/lib/error';
 import EventBus from '@/event-bus';
-
-const prefersDarkMode = window.matchMedia('(prefers-color-scheme: dark)');
+import darkModeMixin from '@/lib/darkMode';
 
 export default {
+  mixins: [darkModeMixin],
   data() {
     return {
       signInFormValid: false,
@@ -368,19 +368,6 @@ export default {
     };
   },
 
-  watch: {
-    darkMode(val) {
-      this.$vuetify.theme.dark = val;
-      if (val && !prefersDarkMode.matches) {
-        localStorage.setItem('darkMode', '1');
-      } else if (!val && prefersDarkMode.matches) {
-        localStorage.setItem('darkMode', '0');
-      } else {
-        localStorage.removeItem('darkMode');
-      }
-    },
-  },
-
   async created() {
     const { status, verificationMethod } = await this.getAuthenticationStatus();
 
@@ -400,25 +387,7 @@ export default {
         throw new Error(`Unknown authentication status: ${status}`);
     }
 
-    const isDarkMode = localStorage.getItem('darkMode');
-    if (isDarkMode !== null) {
-      this.darkMode = isDarkMode === '1';
-    } else {
-      this.darkModeListener = (e) => {
-        this.darkMode = e.matches;
-      };
-      prefersDarkMode.addEventListener('change', this.darkModeListener);
-
-      if (prefersDarkMode.matches) {
-        this.darkMode = true;
-      }
-    }
-  },
-
-  beforeDestroy() {
-    if (this.darkModeListener) {
-      prefersDarkMode.removeEventListener('change', this.darkModeListener);
-    }
+    this.initDarkMode();
   },
 
   computed: {

--- a/web/src/views/Auth.vue
+++ b/web/src/views/Auth.vue
@@ -371,6 +371,13 @@ export default {
   watch: {
     darkMode(val) {
       this.$vuetify.theme.dark = val;
+      if (val && !prefersDarkMode.matches) {
+        localStorage.setItem('darkMode', '1');
+      } else if (!val && prefersDarkMode.matches) {
+        localStorage.setItem('darkMode', '0');
+      } else {
+        localStorage.removeItem('darkMode');
+      }
     },
   },
 
@@ -397,13 +404,20 @@ export default {
     if (isDarkMode !== null) {
       this.darkMode = isDarkMode === '1';
     } else {
-      prefersDarkMode.addEventListener('change', (e) => {
+      this.darkModeListener = (e) => {
         this.darkMode = e.matches;
-      });
+      };
+      prefersDarkMode.addEventListener('change', this.darkModeListener);
 
-      if (prefersDarkMode.matches && localStorage.getItem('darkMode') !== '0') {
+      if (prefersDarkMode.matches) {
         this.darkMode = true;
       }
+    }
+  },
+
+  beforeDestroy() {
+    if (this.darkModeListener) {
+      prefersDarkMode.removeEventListener('change', this.darkModeListener);
     }
   },
 

--- a/web/src/views/Auth.vue
+++ b/web/src/views/Auth.vue
@@ -337,6 +337,8 @@ import axios from 'axios';
 import { getErrorMessage } from '@/lib/error';
 import EventBus from '@/event-bus';
 
+const prefersDarkMode = window.matchMedia('(prefers-color-scheme: dark)');
+
 export default {
   data() {
     return {
@@ -351,6 +353,7 @@ export default {
 
       loginHelpDialog: null,
 
+      darkMode: false,
       oidcProviders: [],
       loginWithPassword: null,
       authMethods: {},
@@ -363,6 +366,12 @@ export default {
       verificationEmailSending: false,
 
     };
+  },
+
+  watch: {
+    darkMode(val) {
+      this.$vuetify.theme.dark = val;
+    },
   },
 
   async created() {
@@ -382,6 +391,19 @@ export default {
         break;
       default:
         throw new Error(`Unknown authentication status: ${status}`);
+    }
+
+    const isDarkMode = localStorage.getItem('darkMode');
+    if (isDarkMode !== null) {
+      this.darkMode = isDarkMode === '1';
+    } else {
+      prefersDarkMode.addEventListener('change', (e) => {
+        this.darkMode = e.matches;
+      });
+
+      if (prefersDarkMode.matches && localStorage.getItem('darkMode') !== '0') {
+        this.darkMode = true;
+      }
     }
   },
 


### PR DESCRIPTION
Currently by default semaphore is shown using the light theme and does not change based on the current system dark mode setting.

I often find myself toggling the system light theme during the day and the dark mode at night. Most browsers, websites and my IDE all automatically update to reflect the system setting.

This PR uses the browsers `prefers-color-scheme` media query, which takes into account your system theme settings.


[Screencast from 2023-06-19 19-07-04.webm](https://github.com/ansible-semaphore/semaphore/assets/144435/b6b48cb6-b0ad-4f4b-8f69-30e13f211f08)
