### PR TITLE
Correctly display relative time for non-UTC timezones

### DIFF
--- a/web/src/main.js
+++ b/web/src/main.js
@@ -12,7 +12,7 @@ const convert = new Convert();
 axios.defaults.baseURL = document.baseURI;
 Vue.config.productionTip = false;
 
-Vue.filter('formatDate', (value) => (value ? moment(String(value)).fromNow() : '—'));
+Vue.filter('formatDate', (value) => (value ? moment.utc(String(value)).local(true).fromNow() : '—'));
 Vue.filter('formatTime', (value) => (value ? moment(String(value)).format('LTS') : '—'));
 Vue.filter('formatLog', (value) => (value ? convert.toHtml(String(value)) : value));
 


### PR DESCRIPTION
This is to display correct relative time in "History" tab when local timezone is other then UTC