### PR TITLE
fix: set task status when stopping it

### DIFF
--- a/services/tasks/pool.go
+++ b/services/tasks/pool.go
@@ -218,12 +218,15 @@ func (p *TaskPool) StopTask(targetTask db.Task) error {
 		tsk.setStatus(db.TaskStoppingStatus)
 		if status == db.TaskRunningStatus {
 			if tsk.process == nil {
+			    tsk.setStatus(db.TaskFailStatus)
 				panic("running process can not be nil")
 			}
 			err := tsk.process.Kill()
 			if err != nil {
+			    tsk.setStatus(db.TaskFailStatus)
 				return err
 			}
+			tsk.setStatus(db.TaskStoppedStatus)
 		}
 	}
 

--- a/services/tasks/pool.go
+++ b/services/tasks/pool.go
@@ -218,12 +218,12 @@ func (p *TaskPool) StopTask(targetTask db.Task) error {
 		tsk.setStatus(db.TaskStoppingStatus)
 		if status == db.TaskRunningStatus {
 			if tsk.process == nil {
-			    tsk.setStatus(db.TaskFailStatus)
+				tsk.setStatus(db.TaskFailStatus)
 				panic("running process can not be nil")
 			}
 			err := tsk.process.Kill()
 			if err != nil {
-			    tsk.setStatus(db.TaskFailStatus)
+				tsk.setStatus(db.TaskFailStatus)
 				return err
 			}
 			tsk.setStatus(db.TaskStoppedStatus)


### PR DESCRIPTION
Should allow users to manually stop tasks that miss their process (_orphaned_)
For now only manual editing of the database task-table can remove them.

Related to:
* https://github.com/ansible-semaphore/semaphore/issues/1385
* https://github.com/ansible-semaphore/semaphore/issues/1376
* https://github.com/ansible-semaphore/semaphore/discussions/1384
* https://github.com/ansible-semaphore/semaphore/issues/1311

\- AnsibleGuy