### PR TITLE
feat: added basic github issue-forms

### DIFF
--- a/.github/ISSUE_TEMPLATES/documentation.yml
+++ b/.github/ISSUE_TEMPLATES/documentation.yml
@@ -1,0 +1,48 @@
+---
+
+name: Documentation
+description: You have a found missing or invalid documentation
+title: "Docs: "
+labels: ['documentation', 'triage']
+
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Please make sure to go through these steps **before opening an issue**:
+        
+        - [ ] Read the [documentation](https://docs.ansible-semaphore.com/)
+          - [ ] Read the [troubleshooting guide](https://docs.ansible-semaphore.com/administration-guide/troubleshooting)
+          - [ ] Read the [documentation regarding manual installations](https://docs.ansible-semaphore.com/administration-guide/installation_manually) if you did install Semaphore that way
+
+        - [ ] Check if there are existing [issues](https://github.com/ansible-semaphore/semaphore/issues) or [discussions](https://github.com/ansible-semaphore/semaphore/discussions) regarding your topic
+
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem
+      description: |
+        Describe what part of the documentation is missing or wrong!
+        Please also tell us what you would expected to find.
+        What would you change or add?
+    validations:
+      required: true
+
+  - type: dropdown
+    id: related-to
+    attributes:
+      label: Related to
+      description: |
+        To what parts of Semaphore is the documentation related? (if any)
+
+      multiple: true
+      options:
+        - Web-Frontend (what users interact with)
+        - Web-Backend (APIs)
+        - Service (scheduled tasks, alerts)
+        - Ansible (task execution)
+        - Configuration
+        - Database
+        - Docker
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATES/feature_request.yml
+++ b/.github/ISSUE_TEMPLATES/feature_request.yml
@@ -1,0 +1,94 @@
+---
+
+name: Feature request
+description: You would like to have a new feature implemented
+title: "Feature: "
+labels: ['feature', 'triage']
+
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Please make sure to go through these steps **before opening an issue**:
+        
+        - [ ] Read the [documentation](https://docs.ansible-semaphore.com/)
+          - [ ] Read the [troubleshooting guide](https://docs.ansible-semaphore.com/administration-guide/troubleshooting)
+          - [ ] Read the [documentation regarding manual installations](https://docs.ansible-semaphore.com/administration-guide/installation_manually) if you did install Semaphore that way
+
+        - [ ] Check if there are existing [issues](https://github.com/ansible-semaphore/semaphore/issues) or [discussions](https://github.com/ansible-semaphore/semaphore/discussions) regarding your topic
+
+  - type: dropdown
+    id: related-to
+    attributes:
+      label: Related to
+      description: |
+        To what parts of Semaphore is the feature related?
+
+      multiple: true
+      options:
+        - Web-Frontend (what users interact with)
+        - Web-Backend (APIs)
+        - Service (scheduled tasks, alerts)
+        - Ansible (task execution)
+        - Configuration
+        - Database
+        - Docker
+        - Other
+    validations:
+      required: true
+
+  - type: dropdown
+    id: impact
+    attributes:
+      label: Impact
+      description: |
+        What impact would the feature have for Semaphore users?
+
+      multiple: false
+      options:
+        - nice to have
+        - nice to have for enterprise usage
+        - better user experience
+        - security improvements
+        - major improvement to user experience
+        - must have for enterprise usage
+        - must have
+    validations:
+      required: true
+
+  - type: textarea
+    id: feature
+    attributes:
+      label: Missing Feature
+      description: |
+        Describe the feature you are missing.
+        Why would you like to see such a feature being implemented?
+
+    validations:
+      required: true
+
+  - type: textarea
+    id: implementation
+    attributes:
+      label: Implementation
+      description: |
+        Please think about how the feature should be implemented.
+        What would you suggest?
+        How should it look and behave?
+
+    validations:
+      required: true
+
+  - type: textarea
+    id: design
+    attributes:
+      label: Design
+      description: |
+        If you have programming experience yourself:
+        Please provide us with an example how you would design this feature.
+
+        What edge-cases need to be covered?
+        Are there relations to other components that need to be though of?
+
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATES/problem.yml
+++ b/.github/ISSUE_TEMPLATES/problem.yml
@@ -1,0 +1,169 @@
+---
+
+name: Problem
+description: You have encountered problems when using Semaphore
+title: "Problem: "
+labels: ['problem', 'triage']
+
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Please make sure to go through these steps **before opening an issue**:
+        
+        - [ ] Read the [documentation](https://docs.ansible-semaphore.com/)
+          - [ ] Read the [troubleshooting guide](https://docs.ansible-semaphore.com/administration-guide/troubleshooting)
+          - [ ] Read the [documentation regarding manual installations](https://docs.ansible-semaphore.com/administration-guide/installation_manually) if you don't use docker
+
+        - [ ] Check if there are existing [issues](https://github.com/ansible-semaphore/semaphore/issues) or [discussions](https://github.com/ansible-semaphore/semaphore/discussions) regarding your topic
+
+  - type: textarea
+    id: problem
+    attributes:
+      label: Issue
+      description: |
+        Describe the problem you encountered and tell us what you would have expected to happen
+
+    validations:
+      required: true
+
+  - type: dropdown
+    id: impact
+    attributes:
+      label: Impact
+      description: |
+        What parts of Semaphore are impacted by the problem?
+
+      multiple: true
+      options:
+        - Web-Frontend (what users interact with)
+        - Web-Backend (APIs)
+        - Service (scheduled tasks, alerts)
+        - Ansible (task execution)
+        - Configuration
+        - Database
+        - Docker
+        - Semaphore Project
+        - Other
+    validations:
+      required: true
+
+  - type: dropdown
+    id: install-method
+    attributes:
+      label: Installation method
+      description: |
+        How did you install Semaphore?
+
+      multiple: false
+      options:
+        - Docker
+        - Package
+        - Binary
+        - Snap
+    validations:
+      required: true
+
+  - type: dropdown
+    id: browsers
+    attributes:
+      label: Browser
+      description: |
+        If the problem occurs in the Semaphore WebUI - in what browsers do you see it?
+
+      multiple: true
+      options:
+        - Firefox
+        - Chrome
+        - Safari
+        - Microsoft Edge
+        - Opera
+
+  - type: textarea
+    id: version-semaphore
+    attributes:
+      label: Semaphore Version
+      description: |
+        What version of Semaphore are you running?
+        > Command: `semaphore version`
+    validations:
+      required: true
+
+  - type: textarea
+    id: version-ansible
+    attributes:
+      label: Ansible Version
+      description: |
+        If your problem occurs when executing a task:
+        > What version of Ansible are you running?
+        > Command: `ansible --version`
+
+        If your problem occurs when executing a specific Ansible Module:
+        > Provide the Ansible Module versions!
+        > Command: `ansible-galaxy collection list`
+
+      render: bash
+    validations:
+      required: false
+
+  - type: textarea
+    id: logs
+    attributes:
+      label: Logs & errors
+      description: |
+        Provide logs and error messages you have encountered!
+        
+        Logs of the service:
+        > Docker command: `docker logs <container-name>`
+        > Systemd command: `journalctl -u <serivce-name> --no-pager --full -n 250`
+
+        If the error occurs in the WebUI:
+        > please add a screenshot
+        > check your browser console for errors (`F12` in most browsers)
+
+        Tip: You can attach images or log files by clicking this area to highlight it and then dragging files in.
+
+    validations:
+      required: false
+
+  - type: textarea
+    id: manual-installation
+    attributes:
+      label: Manual installation - system information
+      description: |
+        If you have installed Semaphore using the package or binary:
+        
+        Please share your operating system & -version!
+        > Command: `uname -a`
+        
+        What reverse proxy are you using?
+    validations:
+      required: false
+
+  - type: textarea
+    id: config
+    attributes:
+      label: Configuration
+      description: |
+        Please provide Semaphore configuration related to your problem - like:
+        * Config file options
+        * Environment variables
+        * WebUI configuration
+          * Task templates
+          * Inventories
+          * Environment
+          * Repositories
+          * ...
+
+    validations:
+      required: false
+
+  - type: textarea
+    id: additional
+    attributes:
+      label: Additional information
+      description: |
+        Do you have additional information that could help troubleshoot the problem?
+
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATES/question.yml
+++ b/.github/ISSUE_TEMPLATES/question.yml
@@ -1,0 +1,45 @@
+---
+
+name: Question
+description: You have a question on how to use Semaphore
+title: "Question: "
+labels: ['question', 'triage']
+
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Please make sure to go through these steps **before opening an issue**:
+        
+        - [ ] Read the [documentation](https://docs.ansible-semaphore.com/)
+          - [ ] Read the [troubleshooting guide](https://docs.ansible-semaphore.com/administration-guide/troubleshooting)
+          - [ ] Read the [documentation regarding manual installations](https://docs.ansible-semaphore.com/administration-guide/installation_manually) if you did install Semaphore that way
+
+        - [ ] Check if there are existing [issues](https://github.com/ansible-semaphore/semaphore/issues) or [discussions](https://github.com/ansible-semaphore/semaphore/discussions) regarding your topic
+
+  - type: textarea
+    id: question
+    attributes:
+      label: Question
+    validations:
+      required: true
+
+  - type: dropdown
+    id: related-to
+    attributes:
+      label: Related to
+      description: |
+        To what parts of Semaphore is the question related? (if any)
+
+      multiple: true
+      options:
+        - Web-Frontend (what users interact with)
+        - Web-Backend (APIs)
+        - Service (scheduled tasks, alerts)
+        - Ansible (task execution)
+        - Configuration
+        - Database
+        - Documentation
+        - Docker
+    validations:
+      required: false


### PR DESCRIPTION
Greetings!

I have created some basic [GitHub issue-forms](https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/syntax-for-issue-forms).

This should help with:
* more users being able to solve their problems
* bringing more structure to created issues
* easier maintenance of existing issues

I would also suggest:
* creating the `triage` label that gets removed once a new issue has been checked by a repository maintainer (_filter for new tickets_)
* creating a workflow to [auto-close tickets that are inactive for N days](https://docs.github.com/en/github-ae@latest/actions/managing-issues-and-pull-requests/closing-inactive-issues)