### PR TITLE
Update base docker image from `alpine:3.16` to `alpine:3.18`

### DIFF
--- a/deployment/docker/ci/Dockerfile
+++ b/deployment/docker/ci/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.19-alpine3.16
+FROM golang:1.19-alpine3.18
 
 ENV SEMAPHORE_VERSION="development" SEMAPHORE_ARCH="linux_amd64" \
     SEMAPHORE_CONFIG_PATH="${SEMAPHORE_CONFIG_PATH:-/etc/semaphore}" \

--- a/deployment/docker/ci/dredd.Dockerfile
+++ b/deployment/docker/ci/dredd.Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.19-alpine3.16 as golang
+FROM golang:1.19-alpine3.18 as golang
 
 RUN apk add --no-cache curl git
 

--- a/deployment/docker/dev/Dockerfile
+++ b/deployment/docker/dev/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.19-alpine3.16
+FROM golang:1.19-alpine3.18
 
 ENV SEMAPHORE_VERSION="development" SEMAPHORE_ARCH="linux_amd64" \
     SEMAPHORE_CONFIG_PATH="${SEMAPHORE_CONFIG_PATH:-/etc/semaphore}" \

--- a/deployment/docker/prod/Dockerfile
+++ b/deployment/docker/prod/Dockerfile
@@ -1,5 +1,5 @@
 # ansible-semaphore production image
-FROM golang:1.19-alpine3.16 as builder
+FROM golang:1.19-alpine3.18 as builder
 
 COPY ./ /go/src/github.com/ansible-semaphore/semaphore
 WORKDIR /go/src/github.com/ansible-semaphore/semaphore
@@ -7,7 +7,7 @@ WORKDIR /go/src/github.com/ansible-semaphore/semaphore
 RUN apk add --no-cache -U libc-dev curl nodejs npm git gcc g++ && \
   ./deployment/docker/prod/bin/install
 
-FROM alpine:3.16 as runner
+FROM alpine:3.18 as runner
 LABEL maintainer="Tom Whiston <tom.whiston@gmail.com>"
 
 RUN apk add --no-cache sshpass git curl ansible mysql-client openssh-client-default tini py3-aiohttp && \

--- a/deployment/docker/prod/buildx.Dockerfile
+++ b/deployment/docker/prod/buildx.Dockerfile
@@ -1,5 +1,5 @@
 # ansible-semaphore production image
-FROM --platform=$BUILDPLATFORM golang:1.19-alpine3.16 as builder
+FROM --platform=$BUILDPLATFORM golang:1.19-alpine3.18 as builder
 
 COPY ./ /go/src/github.com/ansible-semaphore/semaphore
 WORKDIR /go/src/github.com/ansible-semaphore/semaphore
@@ -10,7 +10,7 @@ ARG TARGETARCH
 RUN apk add --no-cache -U libc-dev curl nodejs npm git gcc
 RUN ./deployment/docker/prod/bin/install ${TARGETOS} ${TARGETARCH}
 
-FROM alpine:3.16 as runner
+FROM alpine:3.18 as runner
 LABEL maintainer="Tom Whiston <tom.whiston@gmail.com>"
 
 RUN apk add --no-cache sshpass git curl ansible mysql-client openssh-client-default tini py3-aiohttp && \


### PR DESCRIPTION
This PR is picking up what is seams to have been abandoned in #1286. It looks like the changes in that PR were not complete which this PR should do. Also, in order to minimise the impact of the change, I limited only to the base image version update from `alpine:3.16` to `alpine:3.18` and leave the golang version as is. The home is that this will allow for use of newer version of `ansible` as there are newer features that cause the deployments to fail when using this image.