### PR TITLE
feat: python3 requirements-file for docker deployments

### DIFF
--- a/deployment/docker/common/runner-wrapper
+++ b/deployment/docker/common/runner-wrapper
@@ -32,5 +32,11 @@ EOF
     echoerr "Run Semaphore with semaphore runner --config ${SEMAPHORE_CONFIG_PATH}/config.json"
 fi
 
+if [ -f "${SEMAPHORE_CONFIG_PATH}/requirements.txt" ]
+then
+  echo "Installing Python3 requirements..."
+  pip3 install -r "${SEMAPHORE_CONFIG_PATH}/requirements.txt"
+fi
+
 # run our command
 exec "$@"

--- a/deployment/docker/common/semaphore-wrapper
+++ b/deployment/docker/common/semaphore-wrapper
@@ -160,5 +160,11 @@ EOF
     echoerr "Run Semaphore with semaphore server --config ${SEMAPHORE_CONFIG_PATH}/config.json"
 fi
 
+if [ -f "${SEMAPHORE_CONFIG_PATH}/requirements.txt" ]
+then
+  echo "Installing Python3 requirements..."
+  pip3 install -r "${SEMAPHORE_CONFIG_PATH}/requirements.txt"
+fi
+
 # run our command
 exec "$@"

--- a/deployment/docker/dev/Dockerfile
+++ b/deployment/docker/dev/Dockerfile
@@ -6,12 +6,13 @@ ENV SEMAPHORE_VERSION="development" SEMAPHORE_ARCH="linux_amd64" \
 
 # hadolint ignore=DL3013
 RUN apk add --no-cache gcc g++ sshpass git mysql-client python3 py3-pip py-openssl openssl ca-certificates curl curl-dev openssh-client-default tini nodejs npm bash rsync && \
-    apk --update add --virtual build-dependencies python3-dev libffi-dev openssl-dev build-base &&\
+    apk --update add --virtual build-dependencies python3-dev libffi-dev openssl-dev build-base && \
     rm -rf /var/cache/apk/*
 
-RUN pip3 install --upgrade pip cffi &&\
-    apk del build-dependencies   && \
-    pip3 install ansible
+RUN pip3 install --upgrade pip cffi && \
+    apk del build-dependencies && \
+    pip3 install ansible && \
+    touch /etc/semaphore/requirements.txt
 
 RUN adduser -D -u 1002 -g 0 semaphore && \
     mkdir -p /go/src/github.com/ansible-semaphore/semaphore && \
@@ -22,7 +23,7 @@ RUN adduser -D -u 1002 -g 0 semaphore && \
     chown -R semaphore:0 /tmp/semaphore && \
     chown -R semaphore:0 /etc/semaphore && \
     chown -R semaphore:0 /var/lib/semaphore && \
-    ssh-keygen -t rsa -q -f "/root/.ssh/id_rsa" -N ""       && \
+    ssh-keygen -t rsa -q -f "/root/.ssh/id_rsa" -N "" && \
     ssh-keyscan -H github.com > /root/.ssh/known_hosts
 
 RUN cd $(go env GOPATH) && curl -sL https://taskfile.dev/install.sh | sh

--- a/deployment/docker/dev/docker-compose.yml
+++ b/deployment/docker/dev/docker-compose.yml
@@ -21,6 +21,7 @@ services:
       dockerfile: ./deployment/docker/dev/Dockerfile
     volumes:
       - "./../../../:/go/src/github.com/ansible-semaphore/semaphore:rw"
+      # - /path/to/local/requirements.txt:/etc/semaphore/requirements.txt
     environment:
       SEMAPHORE_DB_DIALECT: mysql
       SEMAPHORE_DB_USER: semaphore

--- a/deployment/docker/dev/runner.Dockerfile
+++ b/deployment/docker/dev/runner.Dockerfile
@@ -6,12 +6,13 @@ ENV SEMAPHORE_VERSION="development" SEMAPHORE_ARCH="linux_amd64" \
 
 # hadolint ignore=DL3013
 RUN apk add --no-cache gcc g++ sshpass git mysql-client python3 py3-pip py-openssl openssl ca-certificates curl curl-dev openssh-client-default tini nodejs npm bash rsync && \
-    apk --update add --virtual build-dependencies python3-dev libffi-dev openssl-dev build-base &&\
+    apk --update add --virtual build-dependencies python3-dev libffi-dev openssl-dev build-base && \
     rm -rf /var/cache/apk/*
 
-RUN pip3 install --upgrade pip cffi &&\
-    apk del build-dependencies   && \
-    pip3 install ansible
+RUN pip3 install --upgrade pip cffi && \
+    apk del build-dependencies && \
+    pip3 install ansible && \
+    touch /etc/semaphore/requirements.txt
 
 RUN adduser -D -u 1002 -g 0 semaphore && \
     mkdir -p /go/src/github.com/ansible-semaphore/semaphore && \
@@ -22,7 +23,7 @@ RUN adduser -D -u 1002 -g 0 semaphore && \
     chown -R semaphore:0 /tmp/semaphore && \
     chown -R semaphore:0 /etc/semaphore && \
     chown -R semaphore:0 /var/lib/semaphore && \
-    ssh-keygen -t rsa -q -f "/root/.ssh/id_rsa" -N ""       && \
+    ssh-keygen -t rsa -q -f "/root/.ssh/id_rsa" -N "" && \
     ssh-keyscan -H github.com > /root/.ssh/known_hosts
 
 RUN cd $(go env GOPATH) && curl -sL https://taskfile.dev/install.sh | sh

--- a/deployment/docker/prod/Dockerfile
+++ b/deployment/docker/prod/Dockerfile
@@ -10,7 +10,7 @@ RUN apk add --no-cache -U libc-dev curl nodejs npm git gcc g++ && \
 FROM alpine:3.18 as runner
 LABEL maintainer="Tom Whiston <tom.whiston@gmail.com>"
 
-RUN apk add --no-cache sshpass git curl ansible mysql-client openssh-client-default tini py3-aiohttp && \
+RUN apk add --no-cache sshpass git curl mysql-client openssh-client-default tini python3 py3-pip && \
     adduser -D -u 1001 -G root semaphore && \
     mkdir -p /tmp/semaphore && \
     mkdir -p /etc/semaphore && \
@@ -19,10 +19,16 @@ RUN apk add --no-cache sshpass git curl ansible mysql-client openssh-client-defa
     chown -R semaphore:0 /etc/semaphore && \
     chown -R semaphore:0 /var/lib/semaphore
 
+# system dependencies, common jinja2-filters, common community-modules
+RUN pip3 install ansible aiohttp \
+    jmespath netaddr passlib \
+    pywinrm requests cryptography && \
+    touch /etc/semaphore/requirements.txt
+
 COPY --from=builder /usr/local/bin/semaphore-wrapper /usr/local/bin/
 COPY --from=builder /usr/local/bin/semaphore /usr/local/bin/
 
-RUN chown -R semaphore:0 /usr/local/bin/semaphore-wrapper &&\
+RUN chown -R semaphore:0 /usr/local/bin/semaphore-wrapper && \
     chown -R semaphore:0 /usr/local/bin/semaphore
 
 WORKDIR /home/semaphore

--- a/deployment/docker/prod/docker-compose.yml
+++ b/deployment/docker/prod/docker-compose.yml
@@ -17,6 +17,8 @@ services:
     build:
       context: ./../../../
       dockerfile: ./deployment/docker/prod/Dockerfile
+    # volumes:
+    #   - /path/to/local/requirements.txt:/etc/semaphore/requirements.txt
     environment:
       SEMAPHORE_DB_DIALECT: mysql
       SEMAPHORE_DB_USER: semaphore

--- a/deployment/docker/prod/runner.Dockerfile
+++ b/deployment/docker/prod/runner.Dockerfile
@@ -10,7 +10,7 @@ RUN apk add --no-cache -U libc-dev curl nodejs npm git gcc g++ && \
 FROM alpine:3.18 as runner
 LABEL maintainer="Denis Gukov <denguk@gmail.com>"
 
-RUN apk add --no-cache sshpass git curl ansible mysql-client openssh-client-default tini py3-aiohttp && \
+RUN apk add --no-cache sshpass git curl mysql-client openssh-client-default tini python3 py3-pip && \
     adduser -D -u 1001 -G root semaphore && \
     mkdir -p /tmp/semaphore && \
     mkdir -p /etc/semaphore && \
@@ -19,10 +19,16 @@ RUN apk add --no-cache sshpass git curl ansible mysql-client openssh-client-defa
     chown -R semaphore:0 /etc/semaphore && \
     chown -R semaphore:0 /var/lib/semaphore
 
+# system dependencies, common jinja2-filters, common community-modules
+RUN pip3 install ansible aiohttp \
+    jmespath netaddr passlib \
+    pywinrm requests cryptography && \
+    touch /etc/semaphore/requirements.txt
+
 COPY --from=builder /usr/local/bin/runner-wrapper /usr/local/bin/
 COPY --from=builder /usr/local/bin/semaphore /usr/local/bin/
 
-RUN chown -R semaphore:0 /usr/local/bin/runner-wrapper &&\
+RUN chown -R semaphore:0 /usr/local/bin/runner-wrapper && \
     chown -R semaphore:0 /usr/local/bin/semaphore
 
 WORKDIR /home/semaphore


### PR DESCRIPTION
Greetings!

Many users have problems with installing missing Ansible-Module dependencies! (_Python3 modules_)
This PR would:
* allow docker-users to map a requirements-file as docker-volume
  * therefore enable docker-users to install such dependencies at container-startup
  * lets users control the Ansible-version that is used inside the container
* pre-install some of the most necessary Ansible dependencies at build-time


I think this would be a good update to the user-experience when using the docker deployment!
But the list of pre-installed dependencies at build-time should be kept very tight so it does not get bloated.

Related to:
* https://github.com/ansible-semaphore/semaphore/pull/1198 (discussion leading to this PR)
* https://github.com/ansible-semaphore/semaphore/pull/1250 (similar PR)
* https://github.com/ansible-semaphore/semaphore/issues/1233
* https://github.com/ansible-semaphore/semaphore/issues/1175, https://github.com/ansible-semaphore/semaphore/issues/877 (winrm)
* https://github.com/ansible-semaphore/semaphore/discussions/1109 (ansible version)