### PR TITLE
Recursive Submodule Update on Pull

### DIFF
--- a/db_lib/GoGitClient.go
+++ b/db_lib/GoGitClient.go
@@ -114,7 +114,9 @@ func (c GoGitClient) Pull(r GitRepository) error {
 	}
 
 	// Pull the latest changes from the origin remote and merge into the current branch
-	err = wt.Pull(&git.PullOptions{RemoteName: "origin", Auth: authMethod})
+	err = wt.Pull(&git.PullOptions{RemoteName: "origin", 
+				       Auth: authMethod, 
+				       RecurseSubmodules: git.DefaultSubmoduleRecursionDepth})
 	if err != nil && err != git.NoErrAlreadyUpToDate {
 		r.Logger.Log("Unable to pull latest changes")
 		return err


### PR DESCRIPTION
**Description:**

This PR adjusts the `RecurseSubmodules` option in the `pull` method to ensure recursive updating of submodules. Previously, submodules weren't being recursively updated during a pull operation. With this change, submodules will also be updated up to a depth as defined by `DefaultSubmoduleRecursionDepth`, which is currently set to 10.

**Changes:**
- Modified `RecurseSubmodules` to use `git.DefaultSubmoduleRecursionDepth` in the `pull` method.