### PR TITLE
Add a new type secret in Survey Variable

### DIFF
--- a/web/src/components/SurveyVars.vue
+++ b/web/src/components/SurveyVars.vue
@@ -122,6 +122,9 @@ export default {
       }, {
         id: 'int',
         name: 'Integer',
+      }, {
+        id: 'secret',
+        name: 'Secret',
       }],
     };
   },

--- a/web/src/components/TaskForm.vue
+++ b/web/src/components/TaskForm.vue
@@ -52,6 +52,7 @@
       :hint="v.description"
       v-model="editedEnvironment[v.name]"
       :required="v.required"
+      :type="v.type === 'secret' ?'password' : 'text' "
       :rules="[
           val => !v.required || !!val || v.title + $t('isRequired'),
           val => !val || v.type !== 'int' || /^\d+$/.test(val) ||


### PR DESCRIPTION
Sometimes you want to add a password etc. and hide their value. Therefore, I add a new type 'secret' so this input field will hide the typed value is hidden. 


Relates to #904