### PR TITLE
FIX: add To mail header

### DIFF
--- a/services/tasks/alert.go
+++ b/services/tasks/alert.go
@@ -69,6 +69,7 @@ func (t *TaskRunner) sendMailAlert() {
 			continue
 		}
 
+		mailBuffer.Reset()
 		alert.To = userObj.Email
 		t.panicOnError(tpl.Execute(&mailBuffer, alert), "Can't generate alert template!")
 


### PR DESCRIPTION
As described in https://github.com/ansible-semaphore/semaphore/issues/1603, this fixes the missing To header in email alerts that may cause spamfilters to block the email.

To was added to emailTemplate and Alert struct.
Some stuff needed to be moved within the for loop:
mailBuffer is reset in each loop iteration, so that the mail content is not duplicated.
alert.To is reassigned to the email address of the user and the template is re-executed with the new values.