### PR TITLE
collections should be defined at the project root and not relative to playbooks path

### DIFF
--- a/services/tasks/LocalJob.go
+++ b/services/tasks/LocalJob.go
@@ -395,7 +395,7 @@ func (t *LocalJob) getRepoPath() string {
 }
 
 func (t *LocalJob) installRolesRequirements() error {
-	requirementsFilePath := fmt.Sprintf("%s/roles/requirements.yml", t.getRepoPath())
+	requirementsFilePath := path.Join(t.getRepoPath(), "roles", "requirements.yml")
 	requirementsHashFilePath := fmt.Sprintf("%s.md5", requirementsFilePath)
 
 	if _, err := os.Stat(requirementsFilePath); err != nil {
@@ -430,7 +430,7 @@ func (t *LocalJob) getPlaybookDir() string {
 }
 
 func (t *LocalJob) installCollectionsRequirements() error {
-	requirementsFilePath := path.Join(t.getPlaybookDir(), "collections", "requirements.yml")
+	requirementsFilePath := path.Join(t.getRepoPath(), "collections", "requirements.yml")
 	requirementsHashFilePath := fmt.Sprintf("%s.md5", requirementsFilePath)
 
 	if _, err := os.Stat(requirementsFilePath); err != nil {


### PR DESCRIPTION
collections was being referenced from the playbooks relative directory and should be from the projects root directory.  updated roles for consistency on path joining.  thanks @andreas-marschke for the original find, updating the current codebase as there has been so many changes.

if a playbook is in <proj_root>/sub_folder/playbook.yml the previous code expects collections to be in the sub_folder directory <proj_root>/sub_folder/collections/requirements.yml.  

my proposed changes sets the collections directory to always be in the projects root folder as it does for roles directory currently.   

Now it will look for collections in <proj_root>/collections/requirements.yml as expected. 

this resolves issue https://github.com/ansible-semaphore/semaphore/issues/1144 for No collections requirements file found 