### PR TITLE
Update Cron docs link to v3

### DIFF
--- a/web/src/components/TemplateForm.vue
+++ b/web/src/components/TemplateForm.vue
@@ -43,7 +43,7 @@
           <p>{{ $t('definesAutorunSchedule') }}</p>
           <p>
             {{ $t('forMoreInformationAboutCronSeeThe') }}
-            <a href="https://pkg.go.dev/github.com/robfig/cron#hdr-CRON_Expression_Format"
+            <a href="https://pkg.go.dev/github.com/robfig/cron/v3#hdr-CRON_Expression_Format"
                target="_blank"
             >{{ $t('cronExpressionFormatReference') }}</a>.
           </p>
@@ -271,7 +271,7 @@
 
         <small class="mt-1 mb-4 d-block">
           {{ $t('readThe') }}
-          <a target="_blank" href="https://pkg.go.dev/github.com/robfig/cron#hdr-CRON_Expression_Format">{{ $t('docs') }}</a>
+          <a target="_blank" href="https://pkg.go.dev/github.com/robfig/cron/v3#hdr-CRON_Expression_Format">{{ $t('docs') }}</a>
           {{ $t('toLearnMoreAboutCron') }}
         </small>
 


### PR DESCRIPTION
Semaphore is using v3 of Cron but the docs link in the UI was not updated to point to the new documentation.  This fixes that.