### PR TITLE
fix: #1669

### DIFF
--- a/db/AccessKey.go
+++ b/db/AccessKey.go
@@ -143,7 +143,9 @@ func (key *AccessKey) Install(usage AccessKeyRole, logger lib.Logger) (installat
 		switch key.Type {
 		case AccessKeyLoginPassword:
 			content := make(map[string]string)
-			content["ansible_become_user"] = key.LoginPassword.Login
+			if len(key.LoginPassword.Login) > 0 {
+				content["ansible_become_user"] = key.LoginPassword.Login
+			}
 			content["ansible_become_password"] = key.LoginPassword.Password
 			var bytes []byte
 			bytes, err = json.Marshal(content)


### PR DESCRIPTION
This PR fixes #1669 by only writing the `ansible_become_user` variable to the extra vars file if the become secret actually contains a username.

I tested this with the playbook I was having issues with in #1669.