### PR TITLE
fix(api), return correct template start_version when using sql

### DIFF
--- a/db/sql/template.go
+++ b/db/sql/template.go
@@ -112,6 +112,7 @@ func (d *SqlDb) GetTemplates(projectID int, filter db.TemplateFilter, params db.
 		"pt.allow_override_args_in_task",
 		"pt.vault_key_id",
 		"pt.view_id",
+		"pt.start_version",
 		"pt.`type`").
 		From("project__template pt")
 


### PR DESCRIPTION
I stumbled upon this bug when I was working on #417 
This change definitely does not close the aforementioned issue, but it is a necessary prerequisite.

The gist of this bug is that when when using sql and when requesting the templates list, the response sets `start_version` to null even if the template is of type build. The fix for that is trivial 