### PR TITLE
feat: enable proxy for frontend dev server

### DIFF
--- a/web/vue.config.js
+++ b/web/vue.config.js
@@ -2,6 +2,11 @@ module.exports = {
   configureWebpack: {
     devServer: {
       historyApiFallback: true,
+      proxy: {
+        '^/api': {
+          target: 'http://localhost:3000',
+        },
+      },
     },
   },
   chainWebpack: (config) => {


### PR DESCRIPTION
With this feature you are able to run the backend server within one terminal and the live reloading frontend in another terminal where every api request gets proxied to the backend on http://localhost:3000.

This should also resolve https://github.com/ansible-semaphore/semaphore/discussions/1739 and make the live of frontend developers easier.