### PR TITLE
fix: build with go 1.21

### DIFF
--- a/.github/workflows/beta.yml
+++ b/.github/workflows/beta.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: [ubuntu-latest]
     steps:
       - uses: actions/setup-go@v3
-        with: { go-version: '1.20' }
+        with: { go-version: '1.21' }
 
       - uses: actions/setup-node@v3
         with: { node-version: '16' }
@@ -36,7 +36,7 @@ jobs:
     runs-on: [ubuntu-latest]
     steps:
       - uses: actions/setup-go@v3
-        with: { go-version: '1.20' }
+        with: { go-version: '1.21' }
 
       - run: go install github.com/go-task/task/v3/cmd/task@latest
 

--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: [ubuntu-latest]
     steps:
       - uses: actions/setup-go@v3
-        with: { go-version: '1.20' }
+        with: { go-version: '1.21' }
 
       - uses: actions/setup-node@v3
         with: { node-version: '16' }
@@ -80,7 +80,7 @@ jobs:
     needs: [test-db-migration]
     steps:
       - uses: actions/setup-go@v3
-        with: { go-version: '1.20' }
+        with: { go-version: '1.21' }
 
       - run: go install github.com/go-task/task/v3/cmd/task@latest
 
@@ -96,7 +96,7 @@ jobs:
     if: github.ref == 'refs/heads/develop'
     steps:
       - uses: actions/setup-go@v3
-        with: { go-version: '1.20' }
+        with: { go-version: '1.21' }
 
       - run: go install github.com/go-task/task/v3/cmd/task@latest
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: [ubuntu-latest]
     steps:
       - uses: actions/setup-go@v3
-        with: { go-version: '1.20' }
+        with: { go-version: '1.21' }
 
       - uses: actions/setup-node@v3
         with: { node-version: '16' }
@@ -36,7 +36,7 @@ jobs:
     runs-on: [ubuntu-latest]
     steps:
       - uses: actions/setup-go@v3
-        with: { go-version: '1.20' }
+        with: { go-version: '1.21' }
 
       - run: go install github.com/go-task/task/v3/cmd/task@latest
 

--- a/deployment/docker/ci/Dockerfile
+++ b/deployment/docker/ci/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.20-alpine3.18
+FROM golang:1.21-alpine3.18
 
 ENV SEMAPHORE_VERSION="development" SEMAPHORE_ARCH="linux_amd64" \
     SEMAPHORE_CONFIG_PATH="${SEMAPHORE_CONFIG_PATH:-/etc/semaphore}" \

--- a/deployment/docker/ci/dredd.Dockerfile
+++ b/deployment/docker/ci/dredd.Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.20-alpine3.18 as golang
+FROM golang:1.21-alpine3.18 as golang
 
 RUN apk add --no-cache curl git
 

--- a/deployment/docker/dev/Dockerfile
+++ b/deployment/docker/dev/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.20-alpine3.18
+FROM golang:1.21-alpine3.18
 
 ENV SEMAPHORE_VERSION="development" SEMAPHORE_ARCH="linux_amd64" \
     SEMAPHORE_CONFIG_PATH="${SEMAPHORE_CONFIG_PATH:-/etc/semaphore}" \

--- a/deployment/docker/prod/Dockerfile
+++ b/deployment/docker/prod/Dockerfile
@@ -1,5 +1,5 @@
 # ansible-semaphore production image
-FROM golang:1.20-alpine3.18 as builder
+FROM golang:1.21-alpine3.18 as builder
 
 COPY ./ /go/src/github.com/ansible-semaphore/semaphore
 WORKDIR /go/src/github.com/ansible-semaphore/semaphore

--- a/deployment/docker/prod/buildx.Dockerfile
+++ b/deployment/docker/prod/buildx.Dockerfile
@@ -1,5 +1,5 @@
 # ansible-semaphore production image
-FROM --platform=$BUILDPLATFORM golang:1.20-alpine3.18 as builder
+FROM --platform=$BUILDPLATFORM golang:1.21-alpine3.18 as builder
 
 COPY ./ /go/src/github.com/ansible-semaphore/semaphore
 WORKDIR /go/src/github.com/ansible-semaphore/semaphore

--- a/deployment/docker/prod/runner.buildx.Dockerfile
+++ b/deployment/docker/prod/runner.buildx.Dockerfile
@@ -1,5 +1,5 @@
 # ansible-semaphore production image
-FROM --platform=$BUILDPLATFORM golang:1.20-alpine3.18 as builder
+FROM --platform=$BUILDPLATFORM golang:1.21-alpine3.18 as builder
 
 COPY ./ /go/src/github.com/ansible-semaphore/semaphore
 WORKDIR /go/src/github.com/ansible-semaphore/semaphore

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/ansible-semaphore/semaphore
 
-go 1.20
+go 1.21
 
 require (
 	github.com/Masterminds/squirrel v1.5.4

--- a/web/src/lang/nl.js
+++ b/web/src/lang/nl.js
@@ -238,4 +238,3 @@ export default {
   CreateDemoProject: 'Demo-project aanmaken',
   LeaveProject: 'Project verlaten',
 };
-


### PR DESCRIPTION
Looks like some dependencies rely on Go 1.21 with the current versions shown by the build system, currently it's not able to install go-task anymore. With this change the build system gets updated to Go 1.21.