### PR TITLE
Fix Vue warn NewTaskDialog dev mode

### DIFF
--- a/web/src/components/NewTaskDialog.vue
+++ b/web/src/components/NewTaskDialog.vue
@@ -41,7 +41,7 @@ export default {
   props: {
     value: Boolean,
     projectId: Number,
-    templateId: Number,
+    templateId: [Number, String],
     templateType: String,
     templateAlias: String,
   },


### PR DESCRIPTION
DevMove

Login --> Click **Task Templates** --> Click Button **New Template**

[Vue warn]: Invalid prop: type check failed for prop "templateId". Expected Number with value NaN, got String with value "new".

![image](https://github.com/ansible-semaphore/semaphore/assets/8389347/372d1343-395c-4e26-ad57-9b3305494761)