### PR TITLE
Fix #1074: duplicate template

### DIFF
--- a/web/src/components/TemplateForm.vue
+++ b/web/src/components/TemplateForm.vue
@@ -431,6 +431,7 @@ export default {
           url: `/api/project/${this.projectId}/templates/${this.sourceItemId}`,
           responseType: 'json',
         })).data;
+        this.item.id = null;
       }
 
       this.advancedOptions = this.item.arguments != null || this.item.allow_override_args_in_task;


### PR DESCRIPTION
Previously, duplicating wouldn't work correctly and overwrite the existing task. By explicitly setting the item's ID to null after copying the data, we avoid this behaviour.

See: https://github.com/ansible-semaphore/semaphore/issues/1074, https://github.com/ansible-semaphore/semaphore/issues/1400