### PR TITLE
Fix: Author & Version return values in alerts and Slack template

### DIFF
--- a/services/tasks/alert.go
+++ b/services/tasks/alert.go
@@ -382,7 +382,7 @@ func (t *TaskRunner) alertInfos() (string, string) {
 		author = user.Name
 	}
 
-	return version, author
+	return author, version
 }
 
 func (t *TaskRunner) alertColor(kind string) string {

--- a/services/tasks/templates/slack.tmpl
+++ b/services/tasks/templates/slack.tmpl
@@ -13,7 +13,14 @@
                     "title": "Author",
                     "value": "{{ .Author }}",
                     "short": true
+                },
+                {{ if .Task.Version }}
+                {
+                    "title": "Version",
+                    "value": "{{ .Task.Version }}",
+                    "short": true
                 }
+                {{ end }}
             ]
         }
     ]

--- a/services/tasks/templates/slack.tmpl
+++ b/services/tasks/templates/slack.tmpl
@@ -13,14 +13,14 @@
                     "title": "Author",
                     "value": "{{ .Author }}",
                     "short": true
-                },
                 {{ if .Task.Version }}
+                },
                 {
                     "title": "Version",
                     "value": "{{ .Task.Version }}",
                     "short": true
-                }
                 {{ end }}
+                }
             ]
         }
     ]


### PR DESCRIPTION
With Build Version Enabled:
![image](https://github.com/semaphoreui/semaphore/assets/19252498/482bb6d4-3c12-4762-a461-4211d1bf9662)


Without Build Version Enabled:
![image](https://github.com/semaphoreui/semaphore/assets/19252498/9d64a1b1-5b92-4a8e-a664-e627aaa773c0)
