### PR TITLE
add url for task page to semaphore_vars

### DIFF
--- a/db/Task.go
+++ b/db/Task.go
@@ -1,9 +1,11 @@
 package db
 
 import (
+	"fmt"
 	"time"
 
 	"github.com/ansible-semaphore/semaphore/pkg/task_logger"
+	"github.com/ansible-semaphore/semaphore/util"
 )
 
 // Task is a model of a task which will be executed by the runner
@@ -70,6 +72,15 @@ func (task *Task) GetIncomingVersion(d Store) *string {
 	}
 
 	return buildTask.GetIncomingVersion(d)
+}
+
+func (task *Task) GetUrl() *string {
+	if util.Config.WebHost != "" {
+		taskUrl := fmt.Sprintf("%s/project/%d/history?t=%d", util.Config.WebHost, task.ProjectID, task.ID)
+		return &taskUrl
+	}
+
+	return nil
 }
 
 func (task *Task) ValidateNewTask(template Template) error {

--- a/services/tasks/LocalJob.go
+++ b/services/tasks/LocalJob.go
@@ -69,6 +69,7 @@ func (t *LocalJob) getEnvironmentExtraVars(username string, incomingVersion *str
 	}
 
 	taskDetails["username"] = username
+	taskDetails["url"] = t.Task.GetUrl()
 
 	if t.Template.Type != db.TemplateTask {
 		taskDetails["type"] = t.Template.Type
@@ -106,6 +107,7 @@ func (t *LocalJob) getEnvironmentExtraVarsJSON(username string, incomingVersion 
 	}
 
 	taskDetails["username"] = username
+	taskDetails["url"] = t.Task.GetUrl()
 
 	if t.Template.Type != db.TemplateTask {
 		taskDetails["type"] = t.Template.Type

--- a/services/tasks/TaskRunner_test.go
+++ b/services/tasks/TaskRunner_test.go
@@ -1,7 +1,6 @@
 package tasks
 
 import (
-	"github.com/ansible-semaphore/semaphore/db_lib"
 	"math/rand"
 	"os"
 	"path"
@@ -9,6 +8,8 @@ import (
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/ansible-semaphore/semaphore/db_lib"
 
 	"github.com/ansible-semaphore/semaphore/db"
 	"github.com/ansible-semaphore/semaphore/db/bolt"
@@ -306,7 +307,7 @@ func TestTaskGetPlaybookArgs(t *testing.T) {
 	}
 
 	res := strings.Join(args, " ")
-	if res != "-i /tmp/inventory_0 --extra-vars {\"semaphore_vars\":{\"task_details\":{\"id\":0,\"username\":\"\"}}} test.yml" {
+	if res != "-i /tmp/inventory_0 --extra-vars {\"semaphore_vars\":{\"task_details\":{\"id\":0,\"url\":null,\"username\":\"\"}}} test.yml" {
 		t.Fatal("incorrect result")
 	}
 }
@@ -362,7 +363,7 @@ func TestTaskGetPlaybookArgs2(t *testing.T) {
 	}
 
 	res := strings.Join(args, " ")
-	if res != "-i /tmp/inventory_0 --extra-vars {\"semaphore_vars\":{\"task_details\":{\"id\":0,\"username\":\"\"}}} test.yml" {
+	if res != "-i /tmp/inventory_0 --extra-vars {\"semaphore_vars\":{\"task_details\":{\"id\":0,\"url\":null,\"username\":\"\"}}} test.yml" {
 		t.Fatal("incorrect result")
 	}
 }
@@ -418,7 +419,7 @@ func TestTaskGetPlaybookArgs3(t *testing.T) {
 	}
 
 	res := strings.Join(args, " ")
-	if res != "-i /tmp/inventory_0 --extra-vars {\"semaphore_vars\":{\"task_details\":{\"id\":0,\"username\":\"\"}}} test.yml" {
+	if res != "-i /tmp/inventory_0 --extra-vars {\"semaphore_vars\":{\"task_details\":{\"id\":0,\"url\":null,\"username\":\"\"}}} test.yml" {
 		t.Fatal("incorrect result")
 	}
 }


### PR DESCRIPTION
This PR adds the URL of a task to `semaphore_vars` as injected via extra vars to ansible.

The purpose is to provide the URL of the Semaphore task invocation to user-defined ansible task code so one can directly access the output of a task by navigating to its URL.

Assume the following example ansible playbook:

```yaml
---
- name: Example Playbook
  hosts: localhost
  connection: local
  tasks:
    - name: A block for error handling purposes
      block:
        - name: Say something
          ansible.builtin.debug:
            msg: Hello World

        - name: Enforce fail
          ansible.builtin.fail:
            msg: Fail to trigger rescue tasks
      rescue:
        - name: Send a message to Rocketchat
          community.general.rocketchat:
            domain: "chat.example.com"
            token: "redacted"
            channel: "#foo"
            msg: >
              Playbook execution has failed. More details: {{ semaphore_vars.url | default('not available') }}
          delegate_to: localhost
```

This would send a message to a Rocketchat channel if one of the tasks fail.

The`url` field of `semaphore_vars` will contain the task URL if the `WebHost` config option is set; otherwise it will be set to null.