### PR TITLE
Change the formatLog filter to limit the length of the value

### DIFF
--- a/web/src/main.js
+++ b/web/src/main.js
@@ -15,7 +15,10 @@ Vue.config.productionTip = false;
 
 Vue.filter('formatDate', (value) => (value ? moment(String(value)).fromNow() : '—'));
 Vue.filter('formatTime', (value) => (value ? moment(String(value)).format('LTS') : '—'));
-Vue.filter('formatLog', (value) => (value ? convert.toHtml(String(value)) : value));
+Vue.filter('formatLog', (value) => {
+  if (value.length > 1000) return value;
+  return (value ? convert.toHtml(String(value)) : value);
+});
 
 Vue.filter('formatMilliseconds', (value) => {
   if (value == null || value === '') {


### PR DESCRIPTION
I suggest solving the issue described in #1968 as follows.
In the `formatLog `filter, add a check for the length of the string.If a large string is sent to `convert.toHtml(String(value))`, a RangeError exception will be thrown:
```
vue.runtime.esm.js:1897 RangeError: Maximum call stack size exceeded
    at String.replace (<anonymous>)
    at f (ansi_to_html.js:507:17)
    at D (ansi_to_html.js:517:7)
    at e.value (ansi_to_html.js:605:7)
    at Object.formatLog (main.js:18:53)
    at TaskLogView.vue:1:1858
    at a.Nt [as _l] (vue.runtime.esm.js:2646:16)
    at a.D (TaskLogView.vue:1:1545)
    at e._render (vue.runtime.esm.js:3569:22)
    at a.r (vue.runtime.esm.js:4081:21)
```