### PR TITLE
docker: install ansible-galaxy contents if desired

### DIFF
--- a/deployment/docker/common/semaphore-wrapper
+++ b/deployment/docker/common/semaphore-wrapper
@@ -169,5 +169,14 @@ else
     echoerr "No additional python packages to install"
 fi
 
+# Install ansible-galaxy contents
+if [ -f "${SEMAPHORE_CONFIG_PATH}/requirements.yml" ]; then
+    echoerr "Installing ansible-galaxy contents"
+    ansible-galaxy collection install --upgrade -r "${SEMAPHORE_CONFIG_PATH}/requirements.yml"
+    ansible-galaxy role install --force -r "${SEMAPHORE_CONFIG_PATH}/requirements.yml"
+else
+    echoerr "No ansible-galaxy contents to install"
+fi
+
 # run our command
 exec "$@"


### PR DESCRIPTION
This PR adds the ability to install ansible-galaxy collections and roles on Semaphore startup when using the Docker image, so collections and/or roles don't need to be installed every time a task is launched.

The approach is very similar to what can be accomplished with the "pre-commands" in the systemd service as described in the [manual installation section](https://docs.semui.co/administration-guide/installation_manually#ansible-collections-and-roles-1) of the administration guide.

Assuming you have the following `requirements.yml`:

```yaml
---
collections:
  - name: ansible.posix
    version: "1.5.4"

roles:
  - name: geeringguy.node_exporter
    version: "2.1.0"
```

Mount it to the Semaphore container with the docker compose service entry:

```yaml
---
services:
  semaphore:
    image: semaphoreui/semaphore:latest
    environment: {}
    volumes:
      - path/to/requirements.yml:/etc/semaphore/requirements.yml:ro
```