### PR TITLE
Fix galaxy requirement.yml paths

### DIFF
--- a/db_lib/AnsibleApp.go
+++ b/db_lib/AnsibleApp.go
@@ -91,7 +91,7 @@ func (t *AnsibleApp) getRepoPath() string {
 }
 
 func (t *AnsibleApp) installRolesRequirements() error {
-	requirementsFilePath := fmt.Sprintf("%s/roles/requirements.yml", t.getRepoPath())
+	requirementsFilePath := path.Join(t.getRepoPath(), "roles", "requirements.yml")
 	requirementsHashFilePath := fmt.Sprintf("%s.md5", requirementsFilePath)
 
 	if _, err := os.Stat(requirementsFilePath); err != nil {
@@ -126,7 +126,7 @@ func (t *AnsibleApp) GetPlaybookDir() string {
 }
 
 func (t *AnsibleApp) installCollectionsRequirements() error {
-	requirementsFilePath := path.Join(t.GetPlaybookDir(), "collections", "requirements.yml")
+	requirementsFilePath := path.Join(t.getRepoPath(), "collections", "requirements.yml")
 	requirementsHashFilePath := fmt.Sprintf("%s.md5", requirementsFilePath)
 
 	if _, err := os.Stat(requirementsFilePath); err != nil {


### PR DESCRIPTION
This PR proposes a change to the way of how the path of the Ansible Galaxy requirements.txt is resolved.

For roles, it uses the base path of the cloned repository. This PR does NOT change that, but it updates the code to use the `path` library instead of string concatenation to build the path.

For collections, Semaphore uses the path of the playbook file as a base path to locate the requirements.txt. This is counterintuitive to the roles. Therefore, this PR changes this behaviour to also use the base path of the cloned repository.

This is especially useful when people have their playbooks inside a subfolder.