### PR TITLE
Fix: Alerts for Deploy task shows Build Task ID instead of Build Version

### DIFF
--- a/services/tasks/alert.go
+++ b/services/tasks/alert.go
@@ -364,6 +364,8 @@ func (t *TaskRunner) alertInfos() (string, string) {
 
 	if t.Task.Version != nil {
 		version = *t.Task.Version
+	} else if t.Task.GetIncomingVersion(t.pool.store) != nil {
+		version = "build " + *t.Task.GetIncomingVersion(t.pool.store)
 	} else if t.Task.BuildTaskID != nil {
 		version = "build " + strconv.Itoa(*t.Task.BuildTaskID)
 	} else {

--- a/services/tasks/alert.go
+++ b/services/tasks/alert.go
@@ -8,6 +8,7 @@ import (
 	"strconv"
 	"text/template"
 
+	"github.com/ansible-semaphore/semaphore/db"
 	"github.com/ansible-semaphore/semaphore/pkg/task_logger"
 	"github.com/ansible-semaphore/semaphore/util"
 	"github.com/ansible-semaphore/semaphore/util/mailer"
@@ -364,7 +365,7 @@ func (t *TaskRunner) alertInfos() (string, string) {
 
 	if t.Task.Version != nil {
 		version = *t.Task.Version
-	} else if t.Task.GetIncomingVersion(t.pool.store) != nil {
+	} else if t.Template.Type != db.TemplateTask {
 		version = "build " + *t.Task.GetIncomingVersion(t.pool.store)
 	} else {
 		version = ""

--- a/services/tasks/alert.go
+++ b/services/tasks/alert.go
@@ -366,8 +366,6 @@ func (t *TaskRunner) alertInfos() (string, string) {
 		version = *t.Task.Version
 	} else if t.Task.GetIncomingVersion(t.pool.store) != nil {
 		version = "build " + *t.Task.GetIncomingVersion(t.pool.store)
-	} else if t.Task.BuildTaskID != nil {
-		version = "build " + strconv.Itoa(*t.Task.BuildTaskID)
 	} else {
 		version = ""
 	}


### PR DESCRIPTION
Added condition to get incoming version for Deploy task:

Build: 
![image](https://github.com/semaphoreui/semaphore/assets/19252498/70472fad-3bc8-4b21-be14-7f35f39fbb1e)

Alert for Deploy task showing Build Version: 
![image](https://github.com/semaphoreui/semaphore/assets/19252498/c9d4d591-ea53-46fe-81e0-b8f8831e8cd6)
