### PR TITLE
Trim important fields in repository and inventory forms

### DIFF
--- a/web/src/components/InventoryForm.vue
+++ b/web/src/components/InventoryForm.vue
@@ -52,7 +52,7 @@
     ></v-select>
 
     <v-text-field
-      v-model="item.inventory"
+      v-model.trim="item.inventory"
       :label="$t('pathToInventoryFile')"
       :rules="[v => !!v || $t('path_required')]"
       required
@@ -73,7 +73,7 @@
 
     <codemirror
         :style="{ border: '1px solid lightgray' }"
-        v-model="item.inventory"
+        v-model.trim="item.inventory"
         :options="cmOptions"
         v-if="item.type === 'static' || item.type === 'static-yaml'"
         :placeholder="$t('enterInventory')"

--- a/web/src/components/RepositoryForm.vue
+++ b/web/src/components/RepositoryForm.vue
@@ -21,7 +21,7 @@
     ></v-text-field>
 
     <v-text-field
-        v-model="item.git_url"
+        v-model.trim="item.git_url"
         :label="$t('urlOrPath')"
         :rules="[
           v => !!v || $t('repository_required'),
@@ -56,7 +56,7 @@
     </div>
 
     <v-text-field
-      v-model="item.git_branch"
+      v-model.trim="item.git_branch"
       :label="$t('branch')"
       :rules="[v => (!!v || type === 'local') || $t('branch_required')]"
       required


### PR DESCRIPTION
This will prevent whitespaces at the start or the end of the strings to be saved as part of the inventory path or the repository url/path.

---

I am not at all familiar with Vue, but based on what was done for https://github.com/semaphoreui/semaphore/issues/1019, this should do the trick.