### PR TITLE
 add Inventory ID  when creating tasks

### DIFF
--- a/services/tasks/TaskRunner.go
+++ b/services/tasks/TaskRunner.go
@@ -249,10 +249,15 @@ func (t *TaskRunner) populateDetails() error {
 	}
 
 	// get inventory
-	if t.Template.InventoryID != nil {
-		t.Inventory, err = t.pool.store.GetInventory(t.Template.ProjectID, *t.Template.InventoryID)
+	if t.Task.InventoryID!=nil{
+		t.Inventory, err = t.pool.store.GetInventory(t.Template.ProjectID, *t.Task.InventoryID)
 		if err != nil {
-			return t.prepareError(err, "Template Inventory not found!")
+			if t.Template.InventoryID != nil {
+				t.Inventory, err = t.pool.store.GetInventory(t.Template.ProjectID, *t.Template.InventoryID)
+				if err != nil {
+					return t.prepareError(err, "Template Inventory not found!")
+				}
+			}
 		}
 	}
 

--- a/services/tasks/TaskRunner.go
+++ b/services/tasks/TaskRunner.go
@@ -249,7 +249,7 @@ func (t *TaskRunner) populateDetails() error {
 	}
 
 	// get inventory
-	if t.Task.InventoryID!=nil{
+	if t.Task.InventoryID != nil {
 		t.Inventory, err = t.pool.store.GetInventory(t.Template.ProjectID, *t.Task.InventoryID)
 		if err != nil {
 			if t.Template.InventoryID != nil {
@@ -257,6 +257,13 @@ func (t *TaskRunner) populateDetails() error {
 				if err != nil {
 					return t.prepareError(err, "Template Inventory not found!")
 				}
+			}
+		}
+	} else {
+		if t.Template.InventoryID != nil {
+			t.Inventory, err = t.pool.store.GetInventory(t.Template.ProjectID, *t.Template.InventoryID)
+			if err != nil {
+				return t.prepareError(err, "Template Inventory not found!")
 			}
 		}
 	}


### PR DESCRIPTION
see https://github.com/semaphoreui/semaphore/issues/2283


https://github.com/semaphoreui/semaphore/blob/cde8515fb13cde353c496bec35f00a336947a219/db/Task.go#L52
I saw that the inventory ID has been defined in the database task table, which means we can pass it in from the API, but it has not been processed in the future. I think we can override the inventory in https://github.com/semaphoreui/semaphore/blob/cde8515fb13cde353c496bec35f00a336947a219/services/tasks/TaskRunner.go#L251-L257 to make this configuration effective