### PR TITLE
feat: Add dingtalk webhook notification medium

### DIFF
--- a/cli/setup/setup.go
+++ b/cli/setup/setup.go
@@ -72,11 +72,16 @@ func InteractiveSetup(conf *util.ConfigType) {
 	askConfirmation("Enable Rocket.Chat alerts?", false, &conf.RocketChatAlert)
 	if conf.RocketChatAlert {
 		askValue("Rocket.Chat Webhook URL", "", &conf.RocketChatUrl)
-	}	
+	}
 
 	askConfirmation("Enable Microsoft Team Channel alerts?", false, &conf.MicrosoftTeamsAlert)
 	if conf.MicrosoftTeamsAlert {
 		askValue("Microsoft Teams Webhook URL", "", &conf.MicrosoftTeamsUrl)
+	}
+
+	askConfirmation("Enable DingTalk alerts?", false, &conf.DingTalkAlert)
+	if conf.DingTalkAlert {
+		askValue("DingTalkAlert Webhook URL", "", &conf.DingTalkUrl)
 	}
 
 	askConfirmation("Enable LDAP authentication?", false, &conf.LdapEnable)

--- a/cli/setup/setup.go
+++ b/cli/setup/setup.go
@@ -79,11 +79,6 @@ func InteractiveSetup(conf *util.ConfigType) {
 		askValue("Microsoft Teams Webhook URL", "", &conf.MicrosoftTeamsUrl)
 	}
 
-	askConfirmation("Enable DingTalk alerts?", false, &conf.DingTalkAlert)
-	if conf.DingTalkAlert {
-		askValue("DingTalkAlert Webhook URL", "", &conf.DingTalkUrl)
-	}
-
 	askConfirmation("Enable LDAP authentication?", false, &conf.LdapEnable)
 	if conf.LdapEnable {
 		askValue("LDAP server host", "localhost:389", &conf.LdapServer)

--- a/services/tasks/TaskRunner_logging.go
+++ b/services/tasks/TaskRunner_logging.go
@@ -105,6 +105,7 @@ func (t *TaskRunner) SetStatus(status task_logger.TaskStatus) {
 		t.sendSlackAlert()
 		t.sendRocketChatAlert()
 		t.sendMicrosoftTeamsAlert()
+		t.sendDingTalkAlert()
 	}
 
 	for _, l := range t.statusListeners {

--- a/services/tasks/alert.go
+++ b/services/tasks/alert.go
@@ -359,6 +359,65 @@ func (t *TaskRunner) sendMicrosoftTeamsAlert() {
 	t.Log("Sent successfully microsoft teams alert")
 }
 
+func (t *TaskRunner) sendDingTalkAlert() {
+	if !util.Config.DingTalkAlert || !t.alert {
+		return
+	}
+
+	if t.Template.SuppressSuccessAlerts && t.Task.Status == task_logger.TaskSuccessStatus {
+		return
+	}
+
+	body := bytes.NewBufferString("")
+	author, version := t.alertInfos()
+
+	alert := Alert{
+		Name:   t.Template.Name,
+		Author: author,
+		Color:  t.alertColor("dingtalk"),
+		Task: alertTask{
+			ID:      strconv.Itoa(t.Task.ID),
+			URL:     t.taskLink(),
+			Result:  t.Task.Status.Format(),
+			Version: version,
+			Desc:    t.Task.Message,
+		},
+	}
+
+	tpl, err := template.ParseFS(templates, "templates/dingtalk.tmpl")
+
+	if err != nil {
+		t.Log("Can't parse dingtalk alert template!")
+		panic(err)
+	}
+
+	if err := tpl.Execute(body, alert); err != nil {
+		t.Log("Can't generate dingtalk alert template!")
+		panic(err)
+	}
+
+	if body.Len() == 0 {
+		t.Log("Buffer for dingtalk alert is empty")
+		return
+	}
+
+	t.Log("Attempting to send dingtalk alert")
+
+	resp, err := http.Post(
+		util.Config.DingTalkUrl,
+		"application/json",
+		body,
+	)
+
+	if err != nil {
+		t.Log("Can't send dingtalk alert! Error: " + err.Error())
+	} else if resp.StatusCode != 200 {
+		t.Log("Can't send dingtalk alert! Response code: " + strconv.Itoa(resp.StatusCode))
+	} else {
+		t.Log("Sent successfully dingtalk alert")
+	}
+}
+
 func (t *TaskRunner) alertInfos() (string, string) {
 	version := ""
 

--- a/services/tasks/templates/dingtalk.tmpl
+++ b/services/tasks/templates/dingtalk.tmpl
@@ -1,0 +1,7 @@
+{
+    "msgtype": "markdown",
+    "markdown": {
+        "title": "Task: {{ .Name }}",
+        "text": "#### Task: {{ .Name }}\nExecution #: {{ .Task.ID }}  \nStatus: {{ .Task.Result }}  \nAuthor: {{ .Author }}  \n{{ if .Task.Version }}Version: {{ .Task.Version }}  \n{{ end }}[Task Link]({{ .Task.URL }})"
+    }
+}

--- a/util/config.go
+++ b/util/config.go
@@ -161,7 +161,7 @@ type ConfigType struct {
 	LdapMappings     ldapMappings `json:"ldap_mappings"`
 	LdapNeedTLS      bool         `json:"ldap_needtls" env:"SEMAPHORE_LDAP_NEEDTLS"`
 
-	// Telegram, Slack, Rocket.Chat and Microsoft Teams alerting
+	// Telegram, Slack, Rocket.Chat, Microsoft Teams and DingTalk alerting
 	TelegramAlert       bool   `json:"telegram_alert" env:"SEMAPHORE_TELEGRAM_ALERT"`
 	TelegramChat        string `json:"telegram_chat" env:"SEMAPHORE_TELEGRAM_CHAT"`
 	TelegramToken       string `json:"telegram_token" env:"SEMAPHORE_TELEGRAM_TOKEN"`
@@ -171,6 +171,8 @@ type ConfigType struct {
 	RocketChatUrl       string `json:"rocketchat_url" env:"SEMAPHORE_ROCKETCHAT_URL"`
 	MicrosoftTeamsAlert bool   `json:"microsoft_teams_alert" env:"SEMAPHORE_MICROSOFT_TEAMS_ALERT"`
 	MicrosoftTeamsUrl   string `json:"microsoft_teams_url" env:"SEMAPHORE_MICROSOFT_TEAMS_URL"`
+	DingTalkAlert       bool   `json:"dingtalk_alert" env:"SEMAPHORE_DINGTALK_ALERT"`
+	DingTalkUrl         string `json:"dingtalk_url" env:"SEMAPHORE_DINGTALK_URL"`
 
 	// oidc settings
 	OidcProviders map[string]OidcProvider `json:"oidc_providers"`


### PR DESCRIPTION
Hello, we need to use DingTalk's webhook notification, so we added the code of this notification medium, hoping to merge it in. Because we will push the platform to the production environment for formal use. Thank you~

This code has been tested and verified in the local development environment, and the following is the effect diagram:
![image](https://github.com/user-attachments/assets/81b432a0-21b2-4b62-9a4b-c447769c9863)
