### PR TITLE
feat: Add Gotify alerts

### DIFF
--- a/services/tasks/TaskRunner_logging.go
+++ b/services/tasks/TaskRunner_logging.go
@@ -106,6 +106,7 @@ func (t *TaskRunner) SetStatus(status task_logger.TaskStatus) {
 		t.sendRocketChatAlert()
 		t.sendMicrosoftTeamsAlert()
 		t.sendDingTalkAlert()
+		t.sendGotifyAlert()
 	}
 
 	for _, l := range t.statusListeners {

--- a/services/tasks/templates/gotify.tmpl
+++ b/services/tasks/templates/gotify.tmpl
@@ -1,0 +1,9 @@
+{
+  "extras": {
+    "client::display": {
+      "contentType": "text/markdown"
+    }
+  },
+  "message": "Execution #: {{ .Task.ID }}   \nStatus: {{ .Task.Result }}   \nAuthor: {{ .Author }}   \n{{ if .Task.Version }}Version: {{ .Task.Version }}   \n{{ end }}[Task Link]({{ .Task.URL }})",
+  "title": "Task: {{ .Name }}"
+}

--- a/util/config.go
+++ b/util/config.go
@@ -166,7 +166,7 @@ type ConfigType struct {
 	LdapMappings     *ldapMappings `json:"ldap_mappings,omitempty"`
 	LdapNeedTLS      bool          `json:"ldap_needtls,omitempty" env:"SEMAPHORE_LDAP_NEEDTLS"`
 
-	// Telegram, Slack, Rocket.Chat, Microsoft Teams and DingTalk alerting
+	// Telegram, Slack, Rocket.Chat, Microsoft Teams, DingTalk, and Gotify alerting
 	TelegramAlert       bool   `json:"telegram_alert,omitempty" env:"SEMAPHORE_TELEGRAM_ALERT"`
 	TelegramChat        string `json:"telegram_chat,omitempty" env:"SEMAPHORE_TELEGRAM_CHAT"`
 	TelegramToken       string `json:"telegram_token,omitempty" env:"SEMAPHORE_TELEGRAM_TOKEN"`
@@ -178,6 +178,9 @@ type ConfigType struct {
 	MicrosoftTeamsUrl   string `json:"microsoft_teams_url,omitempty" env:"SEMAPHORE_MICROSOFT_TEAMS_URL"`
 	DingTalkAlert       bool   `json:"dingtalk_alert,omitempty" env:"SEMAPHORE_DINGTALK_ALERT"`
 	DingTalkUrl         string `json:"dingtalk_url,omitempty" env:"SEMAPHORE_DINGTALK_URL"`
+	GotifyAlert         bool   `json:"gotify_alert,omitempty" env:"SEMAPHORE_GOTIFY_ALERT"`
+	GotifyUrl           string `json:"gotify_url,omitempty" env:"SEMAPHORE_GOTIFY_URL"`
+	GotifyToken         string `json:"gotify_token,omitempty" env:"SEMAPHORE_GOTIFY_TOKEN"`
 
 	// oidc settings
 	OidcProviders map[string]OidcProvider `json:"oidc_providers,omitempty"`


### PR DESCRIPTION
This pull request adds [Gotify](https://gotify.net) as an alert target. It's common in homelab environments but we also use it with [Proxmox VE](https://www.proxmox.com/en/proxmox-virtual-environment/overview) for alerts. Adding this would reduce the number of places we have to check for alerts. This request should also close #2383.

These changes are very similar to those for Rocket.Chat(#1836) and DingTalk(#2363). It does not include any changes to `setup.go` for `semaphore setup` because I saw they were removed from the DingTalk pull request.

This request adds three new config variables.
```golang
GotifyAlert  bool   `json:"gotify_alert,omitempty" env:"SEMAPHORE_GOTIFY_ALERT"`
GotifyUrl    string `json:"gotify_url,omitempty"   env:"SEMAPHORE_GOTIFY_URL"`
GotifyToken  string `json:"gotify_token,omitempty" env:"SEMAPHORE_GOTIFY_TOKEN"`
```

It also adds a template for the json request (`services/tasks/templates/gotify.tmpl`) and a function `TaskRunner.sendGotifyAlert()` which is called the same as other alerts in `TaskRunner.SetStatus()`.

This has been tested in a local development version of Semaphore UI with our production version of Gotify.

### Gotify Example
![Screenshot_20241016_085651](https://github.com/user-attachments/assets/d696e95c-6e40-41f9-95d3-b4fde5bed136)