### PR TITLE
Fix ldapmapping panic

### DIFF
--- a/cli/setup/setup.go
+++ b/cli/setup/setup.go
@@ -100,6 +100,7 @@ func InteractiveSetup(conf *util.ConfigType) {
 
 	askConfirmation("Enable LDAP authentication?", false, &conf.LdapEnable)
 	if conf.LdapEnable {
+		conf.LdapMappings = &util.LdapMappings{}
 		askValue("LDAP server host", "localhost:389", &conf.LdapServer)
 		askConfirmation("Enable LDAP TLS connection", false, &conf.LdapNeedTLS)
 		askValue("LDAP DN for bind", "cn=user,ou=users,dc=example", &conf.LdapBindDN)

--- a/util/config.go
+++ b/util/config.go
@@ -43,22 +43,22 @@ type DbConfig struct {
 	Options  map[string]string `json:"options,omitempty" env:"SEMAPHORE_DB_OPTIONS"`
 }
 
-type ldapMappings struct {
+type LdapMappings struct {
 	DN   string `json:"dn" env:"SEMAPHORE_LDAP_MAPPING_DN" default:"dn"`
 	Mail string `json:"mail" env:"SEMAPHORE_LDAP_MAPPING_MAIL" default:"mail"`
 	UID  string `json:"uid" env:"SEMAPHORE_LDAP_MAPPING_UID" default:"uid"`
 	CN   string `json:"cn" env:"SEMAPHORE_LDAP_MAPPING_CN" default:"cn"`
 }
 
-func (p *ldapMappings) GetUsernameClaim() string {
+func (p *LdapMappings) GetUsernameClaim() string {
 	return p.UID
 }
 
-func (p *ldapMappings) GetEmailClaim() string {
+func (p *LdapMappings) GetEmailClaim() string {
 	return p.Mail
 }
 
-func (p *ldapMappings) GetNameClaim() string {
+func (p *LdapMappings) GetNameClaim() string {
 	return p.CN
 }
 
@@ -163,7 +163,7 @@ type ConfigType struct {
 	LdapServer       string        `json:"ldap_server,omitempty" env:"SEMAPHORE_LDAP_SERVER"`
 	LdapSearchDN     string        `json:"ldap_searchdn,omitempty" env:"SEMAPHORE_LDAP_SEARCH_DN"`
 	LdapSearchFilter string        `json:"ldap_searchfilter,omitempty" env:"SEMAPHORE_LDAP_SEARCH_FILTER"`
-	LdapMappings     *ldapMappings `json:"ldap_mappings,omitempty"`
+	LdapMappings     *LdapMappings `json:"ldap_mappings,omitempty"`
 	LdapNeedTLS      bool          `json:"ldap_needtls,omitempty" env:"SEMAPHORE_LDAP_NEEDTLS"`
 
 	// Telegram, Slack, Rocket.Chat, Microsoft Teams, DingTalk, and Gotify alerting
@@ -208,7 +208,7 @@ type ConfigType struct {
 
 func NewConfigType() *ConfigType {
 	return &ConfigType{
-		LdapMappings: &ldapMappings{},
+		LdapMappings: &LdapMappings{},
 	}
 }
 

--- a/util/config.go
+++ b/util/config.go
@@ -206,6 +206,12 @@ type ConfigType struct {
 	Runner *RunnerConfig `json:"runner,omitempty"`
 }
 
+func NewConfigType() *ConfigType {
+	return &ConfigType{
+		LdapMappings: &ldapMappings{},
+	}
+}
+
 // Config exposes the application configuration storage for use in the application
 var Config *ConfigType
 
@@ -218,7 +224,7 @@ func (conf *ConfigType) ToJSON() ([]byte, error) {
 func ConfigInit(configPath string, noConfigFile bool) {
 	fmt.Println("Loading config")
 
-	Config = &ConfigType{}
+	Config = NewConfigType()
 	Config.Apps = map[string]App{}
 
 	if !noConfigFile {

--- a/util/config_test.go
+++ b/util/config_test.go
@@ -116,9 +116,18 @@ func TestCastStringToBool(t *testing.T) {
 
 }
 
+func TestConfigInitialization(t *testing.T) {
+	var testLdapMappingsUID = "uid"
+
+	Config = NewConfigType()
+
+	// should not panic
+	Config.LdapMappings.UID = testLdapMappingsUID
+}
+
 func TestGetConfigValue(t *testing.T) {
 
-	Config = new(ConfigType)
+	Config = NewConfigType()
 
 	var testPort = "1337"
 	var testCookieHash = "0Sn+edH3doJ4EO4Rl49Y0KrxjUkXuVtR5zKHGGWerxQ="


### PR DESCRIPTION
## Description

This pull request addresses and resolves the **config panic** error issue, which occurred under ldap configurations. The bug fix ensures that the system now handles the configuration process more gracefully and avoids panic situations.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

* Added a new unit test that replicates the previous conditions causing the panic.
* Verified that the test suite passes with the fix in place.
