### PR TITLE
Relative Task-Log width

### DIFF
--- a/web/src/App.vue
+++ b/web/src/App.vue
@@ -72,7 +72,7 @@
     <EditDialog
       v-model="taskLogDialog"
       save-button-text="Delete"
-      :max-width="90%"
+      :max-width="'90%'"
       :hide-buttons="true"
       @close="onTaskLogDialogClosed()"
     >

--- a/web/src/App.vue
+++ b/web/src/App.vue
@@ -72,7 +72,7 @@
     <EditDialog
       v-model="taskLogDialog"
       save-button-text="Delete"
-      :max-width="1000"
+      :max-width="90%"
       :hide-buttons="true"
       @close="onTaskLogDialogClosed()"
     >


### PR DESCRIPTION
The task logs in the semaphore are limited to 1000px width. This means that they are quite narrow and difficult to read on monitors with a high resolution. This value should be relative to the resolution, in my example 90%.
This makes the task logs much easier to read.