### PR TITLE
Add config option  to provide environment variables for run apps

### DIFF
--- a/db_lib/AnsiblePlaybook.go
+++ b/db_lib/AnsiblePlaybook.go
@@ -22,8 +22,7 @@ func (p AnsiblePlaybook) makeCmd(command string, args []string, environmentVars 
 	cmd := exec.Command(command, args...) //nolint: gas
 	cmd.Dir = p.GetFullPath()
 
-	cmd.Env = []string{}
-
+	cmd.Env = getEnvironmentVars()
 	cmd.Env = append(cmd.Env, fmt.Sprintf("HOME=%s", util.Config.TmpPath))
 	cmd.Env = append(cmd.Env, fmt.Sprintf("PWD=%s", cmd.Dir))
 	cmd.Env = append(cmd.Env, "PYTHONUNBUFFERED=1")

--- a/db_lib/AnsiblePlaybook.go
+++ b/db_lib/AnsiblePlaybook.go
@@ -22,11 +22,12 @@ func (p AnsiblePlaybook) makeCmd(command string, args []string, environmentVars 
 	cmd := exec.Command(command, args...) //nolint: gas
 	cmd.Dir = p.GetFullPath()
 
-	cmd.Env = getEnvironmentVars()
 	cmd.Env = append(cmd.Env, fmt.Sprintf("HOME=%s", util.Config.TmpPath))
 	cmd.Env = append(cmd.Env, fmt.Sprintf("PWD=%s", cmd.Dir))
 	cmd.Env = append(cmd.Env, "PYTHONUNBUFFERED=1")
 	cmd.Env = append(cmd.Env, "ANSIBLE_FORCE_COLOR=True")
+	cmd.Env = append(cmd.Env, fmt.Sprintf("PATH=%s", os.Getenv("PATH")))
+	cmd.Env = append(cmd.Env, getEnvironmentVars()...)
 
 	// TODO: Following option doesn't work when password authentication used.
 	// 		 So, we need to check args for --ask-pass, --ask-become-pass or remove this code completely.

--- a/db_lib/AnsiblePlaybook.go
+++ b/db_lib/AnsiblePlaybook.go
@@ -22,17 +22,12 @@ func (p AnsiblePlaybook) makeCmd(command string, args []string, environmentVars 
 	cmd := exec.Command(command, args...) //nolint: gas
 	cmd.Dir = p.GetFullPath()
 
-	cmd.Env = append(cmd.Env, fmt.Sprintf("HOME=%s", util.Config.TmpPath))
-	cmd.Env = append(cmd.Env, fmt.Sprintf("PWD=%s", cmd.Dir))
 	cmd.Env = append(cmd.Env, "PYTHONUNBUFFERED=1")
 	cmd.Env = append(cmd.Env, "ANSIBLE_FORCE_COLOR=True")
 	cmd.Env = append(cmd.Env, fmt.Sprintf("PATH=%s", os.Getenv("PATH")))
 	cmd.Env = append(cmd.Env, getEnvironmentVars()...)
-
-	// TODO: Following option doesn't work when password authentication used.
-	// 		 So, we need to check args for --ask-pass, --ask-become-pass or remove this code completely.
-	//       What reason to use this code: prevent hanging of semaphore when host key confirmation required.
-	//cmd.Env = append(cmd.Env, "ANSIBLE_SSH_ARGS=\"-o BatchMode=yes\"")
+	cmd.Env = append(cmd.Env, fmt.Sprintf("HOME=%s", util.Config.TmpPath))
+	cmd.Env = append(cmd.Env, fmt.Sprintf("PWD=%s", cmd.Dir))
 
 	if environmentVars != nil {
 		cmd.Env = append(cmd.Env, *environmentVars...)

--- a/db_lib/LocalApp.go
+++ b/db_lib/LocalApp.go
@@ -3,6 +3,7 @@ package db_lib
 import (
 	"fmt"
 	"os"
+	"strings"
 
 	"github.com/ansible-semaphore/semaphore/pkg/task_logger"
 	"github.com/ansible-semaphore/semaphore/util"
@@ -10,9 +11,19 @@ import (
 
 func getEnvironmentVars() []string {
 	res := []string{}
-	for k, v := range util.Config.EnvironmentVars {
+
+	for _, env := range os.Environ() {
+		for _, allowed := range util.Config.ForwardedEnvVars {
+			if strings.HasPrefix(env, allowed+"=") {
+				res = append(res, env)
+			}
+		}
+	}
+
+	for k, v := range util.Config.EnvVars {
 		res = append(res, fmt.Sprintf("%s=%s", k, v))
 	}
+
 	return res
 }
 

--- a/db_lib/LocalApp.go
+++ b/db_lib/LocalApp.go
@@ -1,6 +1,7 @@
 package db_lib
 
 import (
+	"fmt"
 	"os"
 
 	"github.com/ansible-semaphore/semaphore/pkg/task_logger"
@@ -9,8 +10,8 @@ import (
 
 func getEnvironmentVars() []string {
 	res := []string{}
-	for v, k := range util.Config.EnvironmentVars {
-		res = append(res, v+"="+k)
+	for k, v := range util.Config.EnvironmentVars {
+		res = append(res, fmt.Sprintf("%s=%s", k, v))
 	}
 	return res
 }

--- a/db_lib/LocalApp.go
+++ b/db_lib/LocalApp.go
@@ -4,7 +4,16 @@ import (
 	"os"
 
 	"github.com/ansible-semaphore/semaphore/pkg/task_logger"
+	"github.com/ansible-semaphore/semaphore/util"
 )
+
+func getEnvironmentVars() []string {
+	res := []string{}
+	for v, k := range util.Config.EnvironmentVars {
+		res = append(res, v+"="+k)
+	}
+	return res
+}
 
 type LocalApp interface {
 	SetLogger(logger task_logger.Logger) task_logger.Logger

--- a/db_lib/LocalApp.go
+++ b/db_lib/LocalApp.go
@@ -3,7 +3,6 @@ package db_lib
 import (
 	"fmt"
 	"os"
-	"strings"
 
 	"github.com/ansible-semaphore/semaphore/pkg/task_logger"
 	"github.com/ansible-semaphore/semaphore/util"
@@ -12,11 +11,10 @@ import (
 func getEnvironmentVars() []string {
 	res := []string{}
 
-	for _, env := range os.Environ() {
-		for _, allowed := range util.Config.ForwardedEnvVars {
-			if strings.HasPrefix(env, allowed+"=") {
-				res = append(res, env)
-			}
+	for _, e := range util.Config.ForwardedEnvVars {
+		v := os.Getenv(e)
+		if v != "" {
+			res = append(res, fmt.Sprintf("%s=%s", e, v))
 		}
 	}
 

--- a/db_lib/LocalApp_test.go
+++ b/db_lib/LocalApp_test.go
@@ -1,0 +1,50 @@
+package db_lib
+
+import (
+	"os"
+	"testing"
+
+	"github.com/ansible-semaphore/semaphore/util"
+)
+
+// contains checks if a slice contains a specific string
+func contains(slice []string, item string) bool {
+	for _, s := range slice {
+		if s == item {
+			return true
+		}
+	}
+	return false
+}
+
+func TestGetEnvironmentVars(t *testing.T) {
+
+	os.Setenv("SEMAPHORE_TEST", "test123")
+	os.Setenv("SEMAPHORE_TEST2", "test222")
+	os.Setenv("PASSWORD", "test222")
+
+	util.Config = &util.ConfigType{
+		ForwardedEnvVars: []string{"SEMAPHORE_TEST"},
+		EnvVars: map[string]string{
+			"ANSIBLE_FORCE_COLOR": "False",
+		},
+	}
+
+	res := getEnvironmentVars()
+
+	expected := []string{
+		"SEMAPHORE_TEST=test123",
+		"ANSIBLE_FORCE_COLOR=False",
+	}
+
+	if len(res) != len(expected) {
+		t.Errorf("Expected %v, got %v", expected, res)
+	}
+
+	for _, e := range expected {
+
+		if !contains(res, e) {
+			t.Errorf("Expected %v, got %v", expected, res)
+		}
+	}
+}

--- a/db_lib/ShellApp.go
+++ b/db_lib/ShellApp.go
@@ -45,7 +45,7 @@ func (t *ShellApp) makeCmd(command string, args []string, environmentVars *[]str
 	cmd := exec.Command(command, args...) //nolint: gas
 	cmd.Dir = t.GetFullPath()
 
-	cmd.Env = []string{}
+	cmd.Env = getEnvironmentVars()
 	cmd.Env = append(cmd.Env, fmt.Sprintf("HOME=%s", util.Config.TmpPath))
 	cmd.Env = append(cmd.Env, fmt.Sprintf("PWD=%s", cmd.Dir))
 

--- a/db_lib/TerraformApp.go
+++ b/db_lib/TerraformApp.go
@@ -38,7 +38,7 @@ func (t *TerraformApp) makeCmd(command string, args []string, environmentVars *[
 	cmd := exec.Command(command, args...) //nolint: gas
 	cmd.Dir = t.GetFullPath()
 
-	cmd.Env = []string{}
+	cmd.Env = getEnvironmentVars()
 	cmd.Env = append(cmd.Env, fmt.Sprintf("HOME=%s", util.Config.TmpPath))
 	cmd.Env = append(cmd.Env, fmt.Sprintf("PWD=%s", cmd.Dir))
 

--- a/util/config.go
+++ b/util/config.go
@@ -205,7 +205,9 @@ type ConfigType struct {
 
 	Runner *RunnerConfig `json:"runner,omitempty"`
 
-	EnvironmentVars map[string]string `json:"environment_vars,omitempty" env:"SEMAPHORE_ENVIRONMENT_VARS"`
+	EnvVars map[string]string `json:"env_vars,omitempty" env:"SEMAPHORE_ENV_VARS"`
+
+	ForwardedEnvVars []string `json:"forwarded_env_vars,omitempty" env:"SEMAPHORE_FORWARDED_ENV_VARS"`
 }
 
 func NewConfigType() *ConfigType {

--- a/util/config.go
+++ b/util/config.go
@@ -204,6 +204,8 @@ type ConfigType struct {
 	Apps map[string]App `json:"apps,omitempty" env:"SEMAPHORE_APPS"`
 
 	Runner *RunnerConfig `json:"runner,omitempty"`
+
+	EnvironmentVars map[string]string `json:"environment_vars,omitempty" env:"SEMAPHORE_ENVIRONMENT_VARS"`
 }
 
 func NewConfigType() *ConfigType {

--- a/util/config_test.go
+++ b/util/config_test.go
@@ -30,6 +30,7 @@ func TestLoadEnvironmentToObject(t *testing.T) {
 		Subfield struct {
 			Value string `env:"TEST_VALUE_ENV_VAR"`
 		}
+		StringArr []string `env:"TEST_STRING_ARR"`
 	}
 
 	err := os.Setenv("TEST_FLAG", "yes")
@@ -43,6 +44,11 @@ func TestLoadEnvironmentToObject(t *testing.T) {
 	}
 
 	err = os.Setenv("TEST_VALUE_ENV_VAR", "test_value")
+	if err != nil {
+		panic(err)
+	}
+
+	err = os.Setenv("TEST_STRING_ARR", "[\"test1\",\"test2\"]")
 	if err != nil {
 		panic(err)
 	}
@@ -62,6 +68,18 @@ func TestLoadEnvironmentToObject(t *testing.T) {
 
 	if val.Subfield.Value != "test_value" {
 		t.Error("Invalid value")
+	}
+
+	if val.StringArr == nil {
+		t.Error("Invalid array value")
+	}
+
+	if val.StringArr[0] != "test1" {
+		t.Error("Invalid array item value")
+	}
+
+	if val.StringArr[1] != "test2" {
+		t.Error("Invalid array item value")
 	}
 }
 


### PR DESCRIPTION
In v2.10.32 OS level environment variables has been removed for security reason.

To provide custom environment variables new config option should be used:
* environment var (for Docker):  `SEMAPHORE_ENVIRONMENT_VARS`:
   ```
   -e 'SEMAPHORE_ENV_VARS={"SOME_VAR": "test"}'
   -e 'SEMAPHORE_FORWARDED_ENV_VARS=["VAR1", "VAR2"]'
   ```
* config option `environment_vars`:
   ```
   {
      "env_vars": {"SOME_VAR": "test"},
      "forwarded_env_vars": ["VAR1", "VAR2"],
   }
   ```

Value must be string.