### PR TITLE
Upgrade Ansible, Terraform and Alpine

### DIFF
--- a/deployment/docker/debug/Dockerfile
+++ b/deployment/docker/debug/Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=$BUILDPLATFORM golang:1.22-alpine3.18 as builder
+FROM --platform=$BUILDPLATFORM golang:1.22-alpine3.20 as builder
 
 RUN go install github.com/go-delve/delve/cmd/dlv@latest
 
@@ -25,7 +25,7 @@ RUN --mount=type=cache,target=/go/pkg \
     task deps && \
     task build:debug GOOS=${TARGETOS} GOARCH=${TARGETARCH}
 
-FROM alpine:3.19
+FROM alpine:3.20
 
 RUN apk add --no-cache -U \
 bash curl git gnupg mysql-client openssh-client-default python3 python3-dev py3-pip rsync sshpass tar tini tzdata unzip wget zip build-base openssl-dev libffi-dev cargo && \
@@ -54,7 +54,7 @@ WORKDIR /home/semaphore
 USER 1001
 
 # renovate: datasource=pypi depName=ansible
-ENV ANSIBLE_VERSION 9.4.0
+ENV ANSIBLE_VERSION 10.5.0
 
 RUN mkdir /opt/semaphore/venv
 

--- a/deployment/docker/debug/Dockerfile
+++ b/deployment/docker/debug/Dockerfile
@@ -54,7 +54,7 @@ WORKDIR /home/semaphore
 USER 1001
 
 # renovate: datasource=pypi depName=ansible
-ENV ANSIBLE_VERSION 10.5.0
+ENV ANSIBLE_VERSION 10.6.0
 
 RUN mkdir /opt/semaphore/venv
 

--- a/deployment/docker/runner/Dockerfile
+++ b/deployment/docker/runner/Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=$BUILDPLATFORM golang:1.22-alpine3.18 as builder
+FROM --platform=$BUILDPLATFORM golang:1.22-alpine3.20 as builder
 
 RUN apk add --no-cache -U \
     libc-dev curl nodejs npm git gcc zip unzip tar
@@ -25,7 +25,7 @@ RUN --mount=type=cache,target=/go/pkg \
 
 
 ENV OPENTOFU_VERSION="1.7.0"
-ENV TERRAFORM_VERSION="1.8.2"
+ENV TERRAFORM_VERSION="1.9.8"
 #ENV PULUMI_VERSION="3.116.1"
 
 RUN wget https://github.com/opentofu/opentofu/releases/download/v${OPENTOFU_VERSION}/tofu_${OPENTOFU_VERSION}_linux_${TARGETARCH}.tar.gz && \
@@ -45,7 +45,7 @@ RUN curl -O https://releases.hashicorp.com/terraform/${TERRAFORM_VERSION}/terraf
 #RUN tar xf pulumi.tar.gz --strip-components=1 -C /usr/local/bin
 #RUN rm pulumi.tar.gz
 
-FROM alpine:3.19
+FROM alpine:3.20
 
 ARG TARGETARCH="amd64"
 
@@ -77,7 +77,7 @@ RUN chown -R semaphore:0 /usr/local/bin/runner-wrapper && \
 WORKDIR /home/semaphore
 
 # renovate: datasource=pypi depName=ansible
-ENV ANSIBLE_VERSION 9.4.0
+ENV ANSIBLE_VERSION 10.5.0
 ARG ANSIBLE_VENV_PATH=/opt/semaphore/apps/ansible/${ANSIBLE_VERSION}/venv
 
 RUN apk add --no-cache -U python3-dev build-base openssl-dev libffi-dev cargo && \

--- a/deployment/docker/runner/Dockerfile
+++ b/deployment/docker/runner/Dockerfile
@@ -77,7 +77,7 @@ RUN chown -R semaphore:0 /usr/local/bin/runner-wrapper && \
 WORKDIR /home/semaphore
 
 # renovate: datasource=pypi depName=ansible
-ENV ANSIBLE_VERSION 10.5.0
+ENV ANSIBLE_VERSION 10.6.0
 ARG ANSIBLE_VENV_PATH=/opt/semaphore/apps/ansible/${ANSIBLE_VERSION}/venv
 
 RUN apk add --no-cache -U python3-dev build-base openssl-dev libffi-dev cargo && \

--- a/deployment/docker/server/Dockerfile
+++ b/deployment/docker/server/Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=$BUILDPLATFORM golang:1.22-alpine3.18 as builder
+FROM --platform=$BUILDPLATFORM golang:1.22-alpine3.20 as builder
 
 RUN apk add --no-cache -U \
     libc-dev curl nodejs npm git gcc zip unzip tar
@@ -25,7 +25,7 @@ RUN --mount=type=cache,target=/go/pkg \
 
 
 ENV OPENTOFU_VERSION="1.7.0"
-ENV TERRAFORM_VERSION="1.8.2"
+ENV TERRAFORM_VERSION="1.9.8"
 #ENV PULUMI_VERSION="3.116.1"
 
 RUN wget https://github.com/opentofu/opentofu/releases/download/v${OPENTOFU_VERSION}/tofu_${OPENTOFU_VERSION}_linux_${TARGETARCH}.tar.gz && \
@@ -45,11 +45,11 @@ RUN curl -O https://releases.hashicorp.com/terraform/${TERRAFORM_VERSION}/terraf
 #RUN tar xf pulumi.tar.gz --strip-components=1 -C /usr/local/bin
 #RUN rm pulumi.tar.gz
 
-FROM alpine:3.19
+FROM alpine:3.20
 
 ARG TARGETARCH="amd64"
 # renovate: datasource=pypi depName=ansible
-ENV ANSIBLE_VERSION 9.4.0
+ENV ANSIBLE_VERSION 10.5.0
 ARG ANSIBLE_VENV_PATH=/opt/semaphore/apps/ansible/${ANSIBLE_VERSION}/venv
 
 RUN apk add --no-cache -U \

--- a/deployment/docker/server/Dockerfile
+++ b/deployment/docker/server/Dockerfile
@@ -49,7 +49,7 @@ FROM alpine:3.20
 
 ARG TARGETARCH="amd64"
 # renovate: datasource=pypi depName=ansible
-ENV ANSIBLE_VERSION 10.5.0
+ENV ANSIBLE_VERSION 10.6.0
 ARG ANSIBLE_VENV_PATH=/opt/semaphore/apps/ansible/${ANSIBLE_VERSION}/venv
 
 RUN apk add --no-cache -U \


### PR DESCRIPTION
Alpine 3.18 -> 3.20
Ansible 9.4.0 -> 10.5.0 **Version 9 is EOL next month!**
Terraform 1.8.2 -> 1.9.8

I didn't touch opentofu, since I canot test it.
Also, the web interface of the semaphore was broken when I upgraded the go version from 1.22 to 1.23. So I stayed with version 1.22, but there on alpine 3.20.

Terraform and ansible are working fine, but there is one warning for ansible:

```
[WARNING]: Platform linux on host myvm1 is using the discovered
Python interpreter at /usr/bin/python3.10, but future installation of another
Python interpreter could change the meaning of that path. See
https://docs.ansible.com/ansible-
core/2.17/reference_appendices/interpreter_discovery.html for more information.
```