### PR TITLE
fix(boltdb): Don't return Project schedules in GET template schedules

### DIFF
--- a/db/bolt/schedule.go
+++ b/db/bolt/schedule.go
@@ -62,7 +62,7 @@ func (d *BoltDb) GetProjectSchedules(projectID int) (schedules []db.ScheduleWith
 
 func (d *BoltDb) GetTemplateSchedules(projectID int, templateID int) (schedules []db.Schedule, err error) {
 	schedules, err = d.getProjectSchedules(projectID, func(s db.Schedule) bool {
-		return s.TemplateID == templateID
+		return s.TemplateID == templateID && s.RepositoryID != nil
 	})
 
 	return


### PR DESCRIPTION
This was causing the web UI to delete project schedules associated with the template when it was edited.
Only schedules with a RepositoryID should be returned. SqlDb was already doing this.

Fixes https://github.com/semaphoreui/semaphore/issues/2489