### PR TITLE
Update Dockerfile for Kerberos authentifcation windows

### DIFF
--- a/deployment/docker/server/Dockerfile
+++ b/deployment/docker/server/Dockerfile
@@ -79,12 +79,12 @@ RUN chown -R semaphore:0 /usr/local/bin/server-wrapper && \
 
 WORKDIR /home/semaphore
 
-RUN apk add --no-cache -U python3-dev build-base openssl-dev libffi-dev cargo && \
+RUN apk add --no-cache -U python3-dev build-base openssl-dev libffi-dev cargo libressl-dev cyrus-sasl-gssapiv2 krb5 krb5-libs krb5-dev gcc musl-dev && \
      mkdir -p ${ANSIBLE_VENV_PATH} && \
      python3 -m venv ${ANSIBLE_VENV_PATH} --system-site-packages && \
      source ${ANSIBLE_VENV_PATH}/bin/activate && \
      pip3 install --upgrade pip ansible==${ANSIBLE_VERSION} boto3 botocore requests pywinrm && \
-     apk del python3-dev build-base openssl-dev libffi-dev cargo && \
+     apk del build-base openssl-dev libffi-dev cargo && \
      rm -rf /var/cache/apk/* && \
      find ${ANSIBLE_VENV_PATH} -iname __pycache__ | xargs rm -rf && \
      chown -R semaphore:0 /opt/semaphore


### PR DESCRIPTION
For use this module : gssapi
krb5
kerberos

https://github.com/semaphoreui/semaphore/discussions/2572

I can use kerberos windows authentification if i create this dockerfile
--
FROM semaphoreui/semaphore:v2.10.35
USER root
RUN apk add --no-cache -U --upgrade libressl-dev cyrus-sasl-gssapiv2 krb5 krb5-libs krb5-dev gcc musl-dev python3-dev
COPY krb5.conf /etc/krb5.conf