### PR TITLE
fix: typo in api restore projects url

### DIFF
--- a/web/src/components/RestoreProjectForm.vue
+++ b/web/src/components/RestoreProjectForm.vue
@@ -59,7 +59,7 @@ export default {
     },
 
     getItemsUrl() {
-      return '/api/project/restore';
+      return '/api/projects/restore';
     },
   },
 };


### PR DESCRIPTION
Hello,

This PR fixes #2591, there was a missing "s" in the url to call the api to restore a project from backup !