### PR TITLE
terraform v1.10.1

### DIFF
--- a/deployment/docker/runner/Dockerfile
+++ b/deployment/docker/runner/Dockerfile
@@ -25,7 +25,7 @@ RUN --mount=type=cache,target=/go/pkg \
 
 
 ENV OPENTOFU_VERSION="1.7.0"
-ENV TERRAFORM_VERSION="1.10.0"
+ENV TERRAFORM_VERSION="1.10.1"
 #ENV PULUMI_VERSION="3.116.1"
 
 RUN wget https://github.com/opentofu/opentofu/releases/download/v${OPENTOFU_VERSION}/tofu_${OPENTOFU_VERSION}_linux_${TARGETARCH}.tar.gz && \

--- a/deployment/docker/server/Dockerfile
+++ b/deployment/docker/server/Dockerfile
@@ -25,7 +25,7 @@ RUN --mount=type=cache,target=/go/pkg \
 
 
 ENV OPENTOFU_VERSION="1.7.0"
-ENV TERRAFORM_VERSION="1.10.0"
+ENV TERRAFORM_VERSION="1.10.1"
 #ENV PULUMI_VERSION="3.116.1"
 
 RUN wget https://github.com/opentofu/opentofu/releases/download/v${OPENTOFU_VERSION}/tofu_${OPENTOFU_VERSION}_linux_${TARGETARCH}.tar.gz && \


### PR DESCRIPTION
BUG FIXES:

- cli: Complex variables values set via environment variables were parsed incorrectly during apply (https://github.com/hashicorp/terraform/issues/36121)
- config: templatefile would panic if given and entirely unknown map of variables (https://github.com/hashicorp/terraform/issues/36118)
- config: templatefile would panic if the variables map contains marked values (https://github.com/hashicorp/terraform/issues/36127)
- config: Remove constraint that an expanded resource block must only be used in conjunction with imports using for_each (https://github.com/hashicorp/terraform/issues/36119)
- backend/s3: Lock files could not be written to buckets with object locking enabled (https://github.com/hashicorp/terraform/issues/36120)