### PR TITLE
support previous root collections & roles.

### DIFF
--- a/db_lib/AnsibleApp.go
+++ b/db_lib/AnsibleApp.go
@@ -133,20 +133,42 @@ const (
 )
 
 func (t *AnsibleApp) installRolesRequirements() (err error) {
+	// default roles path
 	err = t.installGalaxyRequirementsFile(GalaxyRole, path.Join(t.GetPlaybookDir(), "roles", "requirements.yml"))
 	if err != nil {
 		return
 	}
 	err = t.installGalaxyRequirementsFile(GalaxyRole, path.Join(t.GetPlaybookDir(), "requirements.yml"))
+	if err != nil {
+		return
+	}
+
+	// alternative roles path
+	err = t.installGalaxyRequirementsFile(GalaxyRole, path.Join(t.getRepoPath(), "roles", "requirements.yml"))
+	if err != nil {
+		return
+	}
+	err = t.installGalaxyRequirementsFile(GalaxyRole, path.Join(t.getRepoPath(), "requirements.yml"))
 	return
 }
 
 func (t *AnsibleApp) installCollectionsRequirements() (err error) {
+	// default collections path
 	err = t.installGalaxyRequirementsFile(GalaxyCollection, path.Join(t.GetPlaybookDir(), "collections", "requirements.yml"))
 	if err != nil {
 		return
 	}
 	err = t.installGalaxyRequirementsFile(GalaxyCollection, path.Join(t.GetPlaybookDir(), "requirements.yml"))
+	if err != nil {
+		return
+	}
+
+	// alternative collections path
+	err = t.installGalaxyRequirementsFile(GalaxyCollection, path.Join(t.getRepoPath(), "collections", "requirements.yml"))
+	if err != nil {
+		return
+	}
+	err = t.installGalaxyRequirementsFile(GalaxyCollection, path.Join(t.getRepoPath(), "requirements.yml"))
 	return
 }
 


### PR DESCRIPTION
This would allow the previous behaviour aswell as the new behaviour : (issue #2519)

Currently allowed :

```
<playbook_dir>/collections/requirements.yml
<playbook_dir>/roles/requirements.yml
```

suggested change :
```
<playbook_dir>/collections/requirements.yml
<playbook_dir>/roles/requirements.yml
<repo_dir>/collections/requirements.yml
<repo_dir>/roles/requirements.yml
```

This makes it possible to utilise subdir's to put the playbooks in, sharing a common role or collection. Eg :

```
/collections/requirements.yml
/debug/play_tester.yml
/maintain/play_maintenance_a.yml
/maintain/play_maintenance_b.yml
```
this makes more sense to maintain then : 

```
/debug/collections/requirements.yml
/debug/play_tester.yml

/maintain/collections/requirements.yml
/maintain/play_maintenance_a.yml
/maintain/play_maintenance_b.yml
```

A more proper way might be possible!