### PR TITLE
runner: remove inventory directory when not empty

### DIFF
--- a/services/tasks/LocalJob_inventory.go
+++ b/services/tasks/LocalJob_inventory.go
@@ -89,7 +89,7 @@ func (t *LocalJob) installStaticInventory() error {
 
 func (t *LocalJob) destroyInventoryFile() {
 	fullPath := t.tmpInventoryFullPath()
-	if err := os.Remove(fullPath); err != nil {
+	if err := os.RemoveAll(fullPath); err != nil {
 		log.Error(err)
 	}
 }


### PR DESCRIPTION
reference this problem issue https://github.com/semaphoreui/semaphore/issues/2645

my local test via

```
task build
task release:test
```

and installing rpm in my testing environment was successfull, inventory directory was removed and the error message in issue is not present.