### PR TITLE
Fixed missing venv in Docker Image, Install Ansible deps as mentioned in your docs

### DIFF
--- a/deployment/docker/server/server-wrapper
+++ b/deployment/docker/server/server-wrapper
@@ -35,6 +35,7 @@ file_env() {
 }
 
 export SEMAPHORE_CONFIG_PATH="${SEMAPHORE_CONFIG_PATH:-/etc/semaphore}"
+export ANSIBLE_VENV_PATH="/opt/semaphore/apps/ansible/${ANSIBLE_VERSION}/venv"
 export SEMAPHORE_DB_PATH="${SEMAPHORE_DB_PATH:-/var/lib/semaphore}"
 export SEMAPHORE_DB_PORT="${SEMAPHORE_DB_PORT:-}"
 
@@ -252,10 +253,25 @@ fi
 #
 if test -f "${SEMAPHORE_CONFIG_PATH}/requirements.txt"; then
     echoerr "Installing additional python dependencies"
+    source ${ANSIBLE_VENV_PATH}/bin/activate
     pip3 install --upgrade \
         -r "${SEMAPHORE_CONFIG_PATH}/requirements.txt"
+    deactivate
+
 else
     echoerr "No additional python dependencies to install"
+fi
+#
+# Install additional ansible dependencies
+#
+if test -f "${SEMAPHORE_CONFIG_PATH}/requirements.yml"; then
+    echoerr "Installing additional ansible dependencies"
+    source ${ANSIBLE_VENV_PATH}/bin/activate
+    ansible-galaxy collection install --upgrade -r "${SEMAPHORE_CONFIG_PATH}/requirements.yml"
+    ansible-galaxy role install --force -r "${SEMAPHORE_CONFIG_PATH}/requirements.yml"
+    deactivate
+else
+    echoerr "No additional ansible dependencies to install"
 fi
 
 


### PR DESCRIPTION
Hi
I added some minior fixes for Docker images.

You can test with my setup as described in:
[https://github.com/joe-speedboat/kube.semaphore](https://github.com/joe-speedboat/kube.semaphore)
on k3s
Or just let met test it.

Thanks
Chris

BTW: I work with AWX most of my time and even if semaphore is missing lot of features from awx, its a great project.
         If you like, I will help you get the most needed features from mid-range enterprise perspective, but I am not willing to buy pro licence for my non comercial home lab and testing.

---
Added ANSIBLE_VENV_PATH variable as exist in Dockerfile
Switched into venv before installing python dependencies 
Install ansible dependencies with venv same way as python