### PR TITLE
Add multiple semver tags to docker releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -87,6 +87,8 @@ jobs:
             maintainer=Semaphore UI <support@semaphoreui.com>
           tags: |
             type=raw,value=${{ github.ref_name }}
+            type=semver,pattern=v{{major}}.{{minor}}
+            type=semver,pattern=v{{major}}
           flavor: |
             latest=true
 
@@ -126,6 +128,8 @@ jobs:
             maintainer=Semaphore UI <support@semaphoreui.com>
           tags: |
             type=raw,value=${{ github.ref_name }}
+            type=semver,pattern=v{{major}}.{{minor}}
+            type=semver,pattern=v{{major}}
           flavor: |
             latest=true
 


### PR DESCRIPTION
Change to GH Workflow that publishes Docker images.

This PR will add additional tags to each release ([Rationale](https://medium.com/@mccode/using-semantic-versioning-for-docker-image-tags-dfde8be06699)). E.g. when releasing `v2.13.1`, additional tags `v2` and `v2.13` are added.  These allow users to pin their preferred main and/or minor version whilst still pulling in patch releases when they are released.