### PR TITLE
fix: Commit hash and overlfow

### DIFF
--- a/web/src/components/NewTaskDialog.vue
+++ b/web/src/components/NewTaskDialog.vue
@@ -3,6 +3,7 @@
     v-model="dialog"
     :save-button-text="$t(TEMPLATE_TYPE_ACTION_TITLES[templateType])"
     :title="$t('newTask')"
+    :max-width="dialogWidth"
     @save="closeDialog"
     @close="closeDialog"
   >
@@ -51,9 +52,15 @@ export default {
   data() {
     return {
       dialog: false,
+      dialogWidth: 400,
       TEMPLATE_TYPE_ACTION_TITLES,
       TEMPLATE_TYPE_ICONS,
     };
+  },
+  mounted() {
+    this.dialogWidth = (window.innerWidth > 450 + this.templateAlias.length
+      && 450 + this.templateAlias.length < 700)
+      ? 450 + this.templateAlias.length : 400;
   },
   watch: {
     async dialog(val) {

--- a/web/src/components/NewTaskDialog.vue
+++ b/web/src/components/NewTaskDialog.vue
@@ -1,7 +1,12 @@
 <template>
-  <EditDialog v-model="dialog" :save-button-text="$t(TEMPLATE_TYPE_ACTION_TITLES[templateType])" :title="$t('newTask')"
-    @save="closeDialog" @close="closeDialog">
-    <template v-slot:title={ }>
+  <EditDialog
+    v-model="dialog"
+    :save-button-text="$t(TEMPLATE_TYPE_ACTION_TITLES[templateType])"
+    :title="$t('newTask')"
+    @save="closeDialog"
+    @close="closeDialog"
+  >
+    <template v-slot:title={}>
       <v-icon small class="mr-4">{{ TEMPLATE_TYPE_ICONS[templateType] }}</v-icon>
       <span class="breadcrumbs__item">{{ templateAlias }}</span>
       <v-icon>mdi-chevron-right</v-icon>
@@ -9,8 +14,16 @@
     </template>
 
     <template v-slot:form="{ onSave, onError, needSave, needReset }">
-      <TaskForm :project-id="projectId" item-id="new" :template-id="templateId" @save="onSave" @error="onError"
-        :need-save="needSave" :need-reset="needReset" :source-task="sourceTask" />
+      <TaskForm
+        :project-id="projectId"
+        item-id="new"
+        :template-id="templateId"
+        @save="onSave"
+        @error="onError"
+        :need-save="needSave"
+        :need-reset="needReset"
+        :source-task="sourceTask"
+      />
     </template>
   </EditDialog>
 </template>

--- a/web/src/components/NewTaskDialog.vue
+++ b/web/src/components/NewTaskDialog.vue
@@ -55,8 +55,6 @@ export default {
       TEMPLATE_TYPE_ICONS,
     };
   },
-  mounted() {
-  },
   watch: {
     async dialog(val) {
       this.$emit('input', val);

--- a/web/src/components/NewTaskDialog.vue
+++ b/web/src/components/NewTaskDialog.vue
@@ -1,13 +1,7 @@
 <template>
-  <EditDialog
-    v-model="dialog"
-    :save-button-text="$t(TEMPLATE_TYPE_ACTION_TITLES[templateType])"
-    :title="$t('newTask')"
-    :max-width="dialogWidth"
-    @save="closeDialog"
-    @close="closeDialog"
-  >
-    <template v-slot:title={}>
+  <EditDialog v-model="dialog" :save-button-text="$t(TEMPLATE_TYPE_ACTION_TITLES[templateType])" :title="$t('newTask')"
+    @save="closeDialog" @close="closeDialog">
+    <template v-slot:title={ }>
       <v-icon small class="mr-4">{{ TEMPLATE_TYPE_ICONS[templateType] }}</v-icon>
       <span class="breadcrumbs__item">{{ templateAlias }}</span>
       <v-icon>mdi-chevron-right</v-icon>
@@ -15,16 +9,8 @@
     </template>
 
     <template v-slot:form="{ onSave, onError, needSave, needReset }">
-      <TaskForm
-        :project-id="projectId"
-        item-id="new"
-        :template-id="templateId"
-        @save="onSave"
-        @error="onError"
-        :need-save="needSave"
-        :need-reset="needReset"
-        :source-task="sourceTask"
-      />
+      <TaskForm :project-id="projectId" item-id="new" :template-id="templateId" @save="onSave" @error="onError"
+        :need-save="needSave" :need-reset="needReset" :source-task="sourceTask" />
     </template>
   </EditDialog>
 </template>
@@ -52,15 +38,11 @@ export default {
   data() {
     return {
       dialog: false,
-      dialogWidth: 400,
       TEMPLATE_TYPE_ACTION_TITLES,
       TEMPLATE_TYPE_ICONS,
     };
   },
   mounted() {
-    this.dialogWidth = (window.innerWidth > 450 + this.templateAlias.length
-      && 450 + this.templateAlias.length < 700)
-      ? 450 + this.templateAlias.length : 400;
   },
   watch: {
     async dialog(val) {

--- a/web/src/components/TaskForm.vue
+++ b/web/src/components/TaskForm.vue
@@ -17,6 +17,7 @@
       dark
       dismissible
       dense
+      @input="item.commit_hash=null"
       v-model="hasCommit"
       class="overflow-hidden mt-2"
     >


### PR DESCRIPTION
- Commit hash were locking the re-runs to stay attached even if you click x button to close and detach it. I fixed this behaviour to make it detach from the commit and fetch the latest when alet is closed
- The new task dialog title was being overflowed hidden when it was too long. I made new task dialog to grow up to 700px depending on title length