### PR TITLE
Fix: Semaphore sql tables can´t handle SHA256 commit hashes

### DIFF
--- a/db/Migration.go
+++ b/db/Migration.go
@@ -81,6 +81,7 @@ func GetMigrations() []Migration {
 		{Version: "2.12.3"},
 		{Version: "2.12.4"},
 		{Version: "2.12.5"},
+		{Version: "2.12.15"},
 	}
 }
 

--- a/db/sql/migrations/v2.12.15.sql
+++ b/db/sql/migrations/v2.12.15.sql
@@ -1,0 +1,5 @@
+alter table `project__schedule`
+    alter column last_commit_hash type varchar(64);
+
+alter table `task`
+    alter column commit_hash type varchar(64);

--- a/db/sql/migrations/v2.12.15.sql
+++ b/db/sql/migrations/v2.12.15.sql
@@ -1,5 +1,2 @@
-alter table `project__schedule`
-    alter column last_commit_hash type varchar(64);
-
-alter table `task`
-    alter column commit_hash type varchar(64);
+alter table `project__schedule` change `last_commit_hash` `last_commit_hash` varchar(64);
+alter table `task` change `commit_hash` `commit_hash` varchar(64);


### PR DESCRIPTION
Fix for #2778 where sql tables can only handle SHA1 commit hashes, but not the newer SHA256 commit hashes