### PR TITLE
Potential fix for code scanning alert no. 37: Email content injection

### DIFF
--- a/util/mailer/mailer.go
+++ b/util/mailer/mailer.go
@@ -5,7 +5,7 @@ import (
 	"net"
 	"net/smtp"
 	"strings"
-	"text/template"
+	"html/template"
 	"time"
 )
 
@@ -60,7 +60,7 @@ func Send(
 		To:      r.Replace(to),
 		From:    r.Replace(from),
 		Subject: r.Replace(subject),
-		Body:    content,
+		Body:    template.HTMLEscapeString(content),
 	})
 
 	if err != nil {


### PR DESCRIPTION
Potential fix for [https://github.com/semaphoreui/semaphore/security/code-scanning/37](https://github.com/semaphoreui/semaphore/security/code-scanning/37)

To fix the problem, we need to sanitize the `content` parameter before using it to construct the email body. This can be done by escaping any HTML content to prevent XSS attacks. We can use the `html/template` package instead of `text/template` to automatically escape HTML content.

1. Replace the import of `text/template` with `html/template`.
2. Ensure that the `content` parameter is properly sanitized by using `html/template` to escape any HTML content.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
