### PR TITLE
fix: runner start command after setup + systemd runner sample

### DIFF
--- a/cli/cmd/runner_setup.go
+++ b/cli/cmd/runner_setup.go
@@ -40,8 +40,8 @@ func doRunnerSetup() int {
 		}
 	}
 
-	fmt.Printf(" Re-launch this program pointing to the configuration file\n\n./semaphore runner --config %v\n\n", resultConfigPath)
-	fmt.Printf(" To run as daemon:\n\nnohup ./semaphore runner --config %v &\n\n", resultConfigPath)
+	fmt.Printf(" Re-launch this program pointing to the configuration file\n\n./semaphore runner start --config %v\n\n", resultConfigPath)
+	fmt.Printf(" To run as daemon:\n\nnohup ./semaphore runner start --config %v &\n\n", resultConfigPath)
 
 	return 0
 }

--- a/deployment/systemd/runner.service
+++ b/deployment/systemd/runner.service
@@ -4,7 +4,7 @@ Requires=network.target
 
 [Service]
 EnvironmentFile=/etc/semaphore/env
-ExecStart=/usr/bin/semaphore runner --config ${SEMAPHORE_CONFIG}
+ExecStart=/usr/bin/semaphore runner start --config ${SEMAPHORE_CONFIG}
 ExecReload=/bin/kill -HUP $MAINPID
 User=semaphore
 Group=semaphore


### PR DESCRIPTION
Fix for the issue #2911 runner start command after setup + systemd runner sample configuration file.