### PR TITLE
fix: use md5 files for each GalaxyRequirementsType

### DIFF
--- a/db_lib/AnsibleApp.go
+++ b/db_lib/AnsibleApp.go
@@ -92,7 +92,7 @@ func (t *AnsibleApp) getRepoPath() string {
 
 func (t *AnsibleApp) installGalaxyRequirementsFile(requirementsType GalaxyRequirementsType, requirementsFilePath string) error {
 
-	requirementsHashFilePath := fmt.Sprintf("%s.md5", requirementsFilePath)
+	requirementsHashFilePath := fmt.Sprintf("%s_%s.md5", requirementsFilePath, requirementsType)
 
 	if _, err := os.Stat(requirementsFilePath); err != nil {
 		t.Log("No " + requirementsFilePath + " file found. Skip galaxy install process.\n")


### PR DESCRIPTION
This solves an issue in installGalaxyRequirementsFile() where only the collections are installed while the requirements.yml file includes both collections and roles. This function is called to install both Galaxy requirements types, however it checks if the requirements has changed before installing.

One the collections were installed, a new call will skip roles installation because the requirements file has not changed since.

Bug observed with v2.13.12