### PR TITLE
fix: fixes incorrect temp path for inventory

### DIFF
--- a/services/tasks/LocalJob_inventory.go
+++ b/services/tasks/LocalJob_inventory.go
@@ -37,7 +37,7 @@ func (t *LocalJob) installInventory() (err error) {
 }
 
 func (t *LocalJob) tmpInventoryFilename() string {
-	return "inventory_" + strconv.Itoa(t.Task.ID)
+	return t.Inventory.Repository.GetDirName(t.Template.ID) + "_inventory_" + strconv.Itoa(t.Inventory.ID)
 }
 
 func (t *LocalJob) tmpInventoryFullPath() string {
@@ -57,7 +57,7 @@ func (t *LocalJob) cloneInventoryRepo() error {
 
 	repo := db_lib.GitRepository{
 		Logger:     t.Logger,
-		TmpDirName: t.Inventory.Repository.GetDirName(t.Template.ID) + "_inventory_" + strconv.Itoa(t.Inventory.ID),
+		TmpDirName: t.tmpInventoryFilename(),
 		Repository: *t.Inventory.Repository,
 		Client:     db_lib.CreateDefaultGitClient(),
 	}

--- a/services/tasks/LocalJob_inventory.go
+++ b/services/tasks/LocalJob_inventory.go
@@ -37,6 +37,9 @@ func (t *LocalJob) installInventory() (err error) {
 }
 
 func (t *LocalJob) tmpInventoryFilename() string {
+	if t.Inventory.Repository == nil {
+		return "inventory_" + strconv.Itoa(t.Inventory.ID)
+	}
 	return t.Inventory.Repository.GetDirName(t.Template.ID) + "_inventory_" + strconv.Itoa(t.Inventory.ID)
 }
 


### PR DESCRIPTION
Following this https://github.com/semaphoreui/semaphore/commit/08b560bd652c8cdc12e9beb6bfd908fa1ca57eac#diff-cdcc879b32ad36a1a5fc057a73351da2506651408ed31898c2ea73b67ea147ab

The temporary path for inventory was wrong causing ansible playbook task to not work correctly:

```
[WARNING]: Unable to parse
8:28:26 PM
/tmp/semaphore/project_1/inventory_149/ciim/ubuntu/inventory as an inventory
8:28:26 PM
source
8:28:26 PM
[WARNING]: No inventory was parsed, only implicit localhost is available
8:28:26 PM
[WARNING]: provided hosts list is empty, only localhost is available. Note that
8:28:26 PM
the implicit localhost does not match 'all'
```

This fix ensures the path is now correctly generated