### PR TITLE
fix: : Correct redirection with `web_host` to /apps endpoint #3027

### DIFF
--- a/web/src/views/project/Templates.vue
+++ b/web/src/views/project/Templates.vue
@@ -90,7 +90,7 @@
             v-if="isAdmin"
             key="other"
             link
-            href="/apps"
+            to="/apps"
           >
             <v-list-item-icon>
               <v-icon>mdi-cogs</v-icon>


### PR DESCRIPTION
## Fix: Correct Redirection with `web_host` #3027


Previously, when a `web_host` (e.g., `/semaphore`) was used, the redirection would incorrectly navigate directly to `/apps` instead of the expected `/<web_host>/apps` (e.g., `/semaphore/apps`).

**Reasoning for the Change:**

The previous implementation used a standard `href` attribute for the link, which always resulted in a full page load and navigation to the absolute path `/apps`, ignoring the `web_host` context.

This change replaces the `href` attribute with the Vue Router's `to` prop. By utilizing `to`, the Vue Router handles the navigation internally, correctly resolving the target path relative to the application's base URL, including the `web_host` if it is defined.

**Testing:**

- Verified that when accessing the application without a `web_host`, the redirection to `/apps` remains correct.
- Confirmed that when accessing the application with a `web_host` (e.g., `/semaphore`), the redirection now correctly navigates to `/<web_host>/apps` (e.g., `/semaphore/apps`).

I was not able to run the dredd tests on my environment (I am really sorry for that). I am also not sure if this change could have impact to other things (I believe it should not). 