### PR TITLE
fix: Correct redirection with `web_host` to tasks `raw_log`.

### DIFF
--- a/web/src/components/TaskLogView.vue
+++ b/web/src/components/TaskLogView.vue
@@ -128,7 +128,7 @@
     <v-btn
       v-if="isTaskStopped"
       color="blue-grey"
-      :href="rawLogURL"
+      :to="rawLogURL"
       class="task-log-action-button"
       style="right: 20px; width: 150px;"
       target="_blank"


### PR DESCRIPTION
# Fix: #3032

Problem similar to the #3028. 

Replacement of `:href` attribute to vue router `:to` atribute. 

**Testing:**

- Verified that when accessing the application without a `web_host`, the redirection to `/api` remains correct.
- Confirmed that when accessing the application with a `web_host` (e.g., `/semaphore`), the redirection now correctly navigates to `/<web_host>/api` (e.g., `/semaphore/api`).
