### PR TITLE
ci: fix ansible version in runner image

### DIFF
--- a/deployment/docker/runner/Dockerfile
+++ b/deployment/docker/runner/Dockerfile
@@ -73,7 +73,8 @@ RUN chown -R semaphore:0 /usr/local/bin/runner-wrapper && \
 WORKDIR /home/semaphore
 
 # renovate: datasource=pypi depName=ansible
-ENV ANSIBLE_VERSION 11.1.0
+ARG ANSIBLE_VERSION=11.1.0
+ENV ANSIBLE_VERSION=${ANSIBLE_VERSION}
 ARG ANSIBLE_VENV_PATH=/opt/semaphore/apps/ansible/${ANSIBLE_VERSION}/venv
 
 RUN apk add --no-cache -U python3-dev build-base openssl-dev libffi-dev cargo && \


### PR DESCRIPTION
# Fix: #3005

This is an additional change probably required to fix the Ansible version in the runner image.

It seems the `ANSIBLE_VERSION` variable in the build task is not being considered by Dockerfile.

https://github.com/semaphoreui/semaphore/blob/bcdb678061027f733d9a2599d607ec315bb71160/.github/workflows/release.yml#L162-L173

I suspect it just needs the same option the server Dockerfile has:

https://github.com/semaphoreui/semaphore/blob/develop/deployment/docker/runner/Dockerfile#L76-L77

https://github.com/semaphoreui/semaphore/blob/develop/deployment/docker/server/Dockerfile#L48-L50