### PR TITLE
fix: add secret survey variable on opentofu task issue #2322

### DIFF
--- a/services/tasks/LocalJob.go
+++ b/services/tasks/LocalJob.go
@@ -67,6 +67,7 @@ func (t *LocalJob) SetCommit(hash, message string) {
 func (t *LocalJob) getEnvironmentExtraVars(username string, incomingVersion *string) (extraVars map[string]any, err error) {
 
 	extraVars = make(map[string]any)
+	extraSecretVars := make(map[string]any)
 
 	if t.Environment.JSON != "" {
 		err = json.Unmarshal([]byte(t.Environment.JSON), &extraVars)
@@ -74,6 +75,15 @@ func (t *LocalJob) getEnvironmentExtraVars(username string, incomingVersion *str
 			return
 		}
 	}
+	if t.Secret != "" {
+		err = json.Unmarshal([]byte(t.Secret), &extraSecretVars)
+		if err != nil {
+			return
+		}
+	}
+	t.Secret = "{}"
+
+	maps.Copy(extraVars, extraSecretVars)
 
 	taskDetails := make(map[string]any)
 


### PR DESCRIPTION
This pull request introduces enhancements to the `getEnvironmentExtraVars` method in `services/tasks/LocalJob.go` to improve the handling of secret variables. The most important change involves merging secret variables into the existing environment variables while ensuring the secret is reset after processing.

### Enhancements to secret variable handling:

* Added a new map, `extraSecretVars`, to handle secret variables separately and parse them from the `t.Secret` JSON string. If parsing fails, the method returns an error.
* Reset the `t.Secret` field to an empty JSON object (`"{}"`) after processing to ensure that secrets are not retained in memory.
* Merged the parsed `extraSecretVars` into the `extraVars` map using `maps.Copy`, consolidating all variables into a single map for further use.

#2322 and #2287 