### PR TITLE
refactor: replace []byte(fmt.Sprintf) with fmt.Appendf

### DIFF
--- a/db/bolt/BoltDb.go
+++ b/db/bolt/BoltDb.go
@@ -77,7 +77,7 @@ type intObjectID int
 type strObjectID string
 
 func (d intObjectID) ToBytes() []byte {
-	return []byte(fmt.Sprintf("%010d", d))
+	return fmt.Appendf(nil, "%010d", d)
 }
 
 func (d strObjectID) ToBytes() []byte {


### PR DESCRIPTION
 This change enhances performance by directly appending the formatted string to the byte slice, avoiding the need for intermediate memory allocation created by fmt.Sprintf. 
 
 The resulting code is cleaner and more efficient, maintaining the same functionality while improving resource usage.
 
 More info can see https://github.com/golang/go/issues/47579