### PR TITLE
fix(notifications): ensure space between icon and text

### DIFF
--- a/pkg/task_logger/task_logger.go
+++ b/pkg/task_logger/task_logger.go
@@ -70,27 +70,27 @@ func (s TaskStatus) Format() (res string) {
 
 	switch s {
 	case TaskWaitingStatus:
-		res += "WAITING"
+		res += " WAITING"
 	case TaskStartingStatus:
-		res += "STARTING"
+		res += " STARTING"
 	case TaskWaitingConfirmation:
-		res += "WAITING_CONFIRMATION"
+		res += " WAITING_CONFIRMATION"
 	case TaskConfirmed:
-		res += "CONFIRMED"
+		res += " CONFIRMED"
 	case TaskRejected:
-		res += "REJECTED"
+		res += " REJECTED"
 	case TaskRunningStatus:
-		res += "RUNNING"
+		res += " RUNNING"
 	case TaskStoppingStatus:
-		res += "STOPPING"
+		res += " STOPPING"
 	case TaskStoppedStatus:
-		res += "STOPPED"
+		res += " STOPPED"
 	case TaskSuccessStatus:
-		res += "SUCCESS"
+		res += " SUCCESS"
 	case TaskFailStatus:
-		res += "ERROR"
+		res += " ERROR"
 	default:
-		res += "UNKNOWN"
+		res += " UNKNOWN"
 	}
 
 	return


### PR DESCRIPTION
Small readability fix in notifications, first one is without my patch, second has the patch:
<img width="417" height="361" alt="image" src="https://github.com/user-attachments/assets/1911e25e-c14d-4394-9150-94eb3f6677ac" />
