### PR TITLE
Potential fix for code scanning alert no. 69: Email content injection

### DIFF
--- a/api/projects/invites.go
+++ b/api/projects/invites.go
@@ -8,6 +8,8 @@ import (
 	"net/http"
 	"time"
 
+	"regexp"
+	"strings"
 	"text/template"
 
 	"github.com/semaphoreui/semaphore/api/helpers"
@@ -17,6 +19,17 @@ import (
 	"github.com/semaphoreui/semaphore/util/mailer"
 	log "github.com/sirupsen/logrus"
 )
+
+// isValidEmail performs rudimentary email validation to avoid header/content injection
+var emailRegex = regexp.MustCompile(`^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}$`)
+func isValidEmail(email string) bool {
+	// Must not contain newlines or percent-encoded variants
+	if strings.ContainsAny(email, "\r\n") || strings.Contains(email, "%0a") || strings.Contains(email, "%0d") {
+		return false
+	}
+	// Must match standard email regex (simple)
+	return emailRegex.MatchString(email)
+}
 
 // InviteMiddleware ensures an invite exists and loads it to the context
 func InviteMiddleware(next http.Handler) http.Handler {
@@ -67,6 +80,14 @@ func CreateInvite(w http.ResponseWriter, r *http.Request) {
 		Email     *string            `json:"email,omitempty"`
 		Role      db.ProjectUserRole `json:"role" binding:"required"`
 		ExpiresAt *time.Time         `json:"expires_at,omitempty"`
+	}
+
+	// Validate email if provided
+	if request.Email != nil {
+		if !isValidEmail(*request.Email) {
+			helpers.WriteErrorStatus(w, "Invalid email address", http.StatusBadRequest)
+			return
+		}
 	}
 
 	if !helpers.Bind(w, r, &request) {

--- a/util/mailer/mailer.go
+++ b/util/mailer/mailer.go
@@ -7,12 +7,24 @@ import (
 	"net"
 	"net/smtp"
 	"strings"
+	"regexp"
 	"text/template"
 	"time"
 
 	"github.com/semaphoreui/semaphore/pkg/tz"
 	"github.com/semaphoreui/semaphore/util"
 )
+
+// isValidEmail performs rudimentary email validation to avoid header/content injection
+var emailRegex = regexp.MustCompile(`^[a-zA-Z0-9._%+\-]+@[a-zA-Z0-9.\-]+\.[a-zA-Z]{2,}$`)
+func isValidEmail(email string) bool {
+	// Must not contain newlines or percent-encoded variants
+	if strings.ContainsAny(email, "\r\n") || strings.Contains(email, "%0a") || strings.Contains(email, "%0d") {
+		return false
+	}
+	// Must match standard email regex (simple)
+	return emailRegex.MatchString(email)
+}
 
 const (
 	mailerBase = "MIME-version: 1.0\r\n" +
@@ -61,6 +73,11 @@ func Send(
 	subject string,
 	content string,
 ) error {
+	// perform robust email validation
+	if !isValidEmail(to) || !isValidEmail(from) {
+		return fmt.Errorf("invalid email address (to or from)")
+	}
+
 	body := bytes.NewBufferString("")
 	tpl, err := template.New("").Parse(mailerBase)
 	if err != nil {

--- a/util/mailer/mailer.go
+++ b/util/mailer/mailer.go
@@ -16,7 +16,7 @@ import (
 )
 
 // isValidEmail performs rudimentary email validation to avoid header/content injection
-var emailRegex = regexp.MustCompile(`^[a-zA-Z0-9._%+\-]+@[a-zA-Z0-9.\-]+\.[a-zA-Z]{2,}$`)
+var emailRegex = regexp.MustCompile(`^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}$`)
 func isValidEmail(email string) bool {
 	// Must not contain newlines or percent-encoded variants
 	if strings.ContainsAny(email, "\r\n") || strings.Contains(email, "%0a") || strings.Contains(email, "%0d") {


### PR DESCRIPTION
Potential fix for [https://github.com/semaphoreui/semaphore/security/code-scanning/69](https://github.com/semaphoreui/semaphore/security/code-scanning/69)

To address email content injection, sanitize and strictly validate any user-supplied inputs before they are used in email headers (`To`, `From`, `Subject`) or the body. Specifically:

- **Email addresses:**  Use a regex or a library to ensure email addresses are valid and safe (no newlines, commas, or extra headers).
- **Subject and Body:**  Escape template variables inserted into the body or subject to avoid HTML/script injection.
- **Where to apply changes:**  
  - In `api/projects/invites.go`, validate `request.Email` before creating the invite and sending an email.
  - In `util/mailer/mailer.go`, additionally validate the `to` and `from` parameters before constructing and sending the email, using a robust validation function.
- **Implementation:**  
  - Add an email validation function (`isValidEmail`) using regex.
  - Apply `isValidEmail` before using `to`, `from` addresses for SMTP.
  - Optionally, HTML-escape body content if used as HTML (can be done using `html/template` instead of `text/template`, but as the code uses HTML content type, consider switching to `html/template`).
  - Fail early if validation fails, and return errors in place of sending injections.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
