### PR TITLE
Bug fix: No newline after GIT_TERMINAL_PROMPT when constructing env vars

### DIFF
--- a/pkg/ssh/agent.go
+++ b/pkg/ssh/agent.go
@@ -144,7 +144,7 @@ type AccessKeyInstallation struct {
 func (key *AccessKeyInstallation) GetGitEnv() (env []string) {
 	env = make([]string, 0)
 
-	env = append(env, fmt.Sprintln("GIT_TERMINAL_PROMPT=0"))
+	env = append(env, "GIT_TERMINAL_PROMPT=0")
 	if key.SSHAgent != nil {
 		env = append(env, fmt.Sprintf("SSH_AUTH_SOCK=%s", key.SSHAgent.SocketFile))
 		sshCmd := "ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null"


### PR DESCRIPTION
I think we shouldn't be needing a newline at the end of GIT_TERMINAL_PROMPT [here](https://github.com/semaphoreui/semaphore/blob/0c433018b9692e9ec704dba9694bdf044a518f5c/pkg/ssh/agent.go#L147C20-L147C32). This causes errors look like:
```
fatal: bad boolean environment value '0
' for 'GIT_TERMINAL_PROMPT'
```

[There are quite a few issues](https://github.com/search?q=repo%3Asemaphoreui%2Fsemaphore+GIT_TERMINAL_PROMPT&type=issues)  being reported in this repo, but are being solved via changing configurations, repo type etc -- but maybe not appending the newline is a real fix here?