### PR TITLE
Force galaxy requirements install via environment variable.

### DIFF
--- a/db_lib/AnsibleApp.go
+++ b/db_lib/AnsibleApp.go
@@ -26,6 +26,12 @@ func getMD5Hash(filepath string) (string, error) {
 }
 
 func hasRequirementsChanges(requirementsFilePath string, requirementsHashFilePath string) bool {
+	// Setting the below Env lets user force reinstall even though the actual contents of the requirements
+	// file haven't changed, esp when versions aren't being used.
+    if os.Getenv("SEMAPHORE_REINSTALL_GALAXY_REQUIREMENTS") != "" {
+        return true
+    }
+	
 	oldFileMD5HashBytes, err := os.ReadFile(requirementsHashFilePath)
 	if err != nil {
 		return true


### PR DESCRIPTION
This is especially useful when 1) the contents of the requirements file doesn't really change, 2) versions are not being used.