### PR TITLE
Update ansible.cfg for community.general.yaml deprecation

### DIFF
--- a/deployment/docker/server/ansible.cfg
+++ b/deployment/docker/server/ansible.cfg
@@ -1,4 +1,5 @@
 [defaults]
 host_key_checking = False
 bin_ansible_callbacks = True
-stdout_callback = yaml
+stdout_callback = default
+callback_result_format = yaml


### PR DESCRIPTION
community.general.yaml has been removed. The plugin has been superseded by the option `result_format=yaml` in callback plugin ansible.builtin.default from ansible-core 2.13 onwards.  This updates ansible.cfg to be compliant with this deprecation.  Fixes #3401 