### PR TITLE
Fix callback result format in runner's ansible config

### DIFF
--- a/deployment/docker/runner/ansible.cfg
+++ b/deployment/docker/runner/ansible.cfg
@@ -2,4 +2,4 @@
 host_key_checking = False
 bin_ansible_callbacks = True
 stdout_callback = default
-result_format = yaml
+callback_result_format = yaml


### PR DESCRIPTION
Per the [documentation](https://docs.ansible.com/ansible/latest/collections/ansible/builtin/default_callback.html#parameter-result_format), when specifying the callback result format in the ini config, `callback_result_format` shall be used.  `result_format` is intended for use when calling the `ansible.builtin.default` module.