### PR TITLE
feat/staged cli args

### DIFF
--- a/TERRAFORM_ARGS_IMPROVEMENT.md
+++ b/TERRAFORM_ARGS_IMPROVEMENT.md
@@ -25,12 +25,12 @@ type LocalAppRunningArgs struct {
 
 ### 2. Argument Parsing (`services/tasks/LocalJob.go`)
 
-Added `getCLIArgsMap()` function that:
-- Attempts to parse arguments as an array first (backward compatible)
-- Converts array format to map with "default" key automatically
-- Falls back to map format if array parsing fails
-- Returns map representation for all argument types
+Added `convertArgsJSONIfArray()` and `getCLIArgsMap()` functions that:
+- `convertArgsJSONIfArray()`: Checks JSON format and converts array format to map with "default" key **in-place**
+- `getCLIArgsMap()`: Parses arguments as map format (after conversion)
+- Array format is automatically converted to map format at runtime
 - Supports both Template and Task level arguments
+- Ensures consistent map-based interface throughout the system
 
 ### 3. Terraform Argument Processing (`services/tasks/LocalJob.go`)
 
@@ -167,7 +167,9 @@ For each stage, arguments are resolved in this order:
 ### Backward Compatibility Details
 
 **Array Format → Map Conversion:**
-- Array `["-var", "foo=bar"]` → Map `{"default": ["-var", "foo=bar"]}`
+- **Runtime Conversion**: Array `["-var", "foo=bar"]` is converted to `{"default": ["-var", "foo=bar"]}` **in-place** when the task runs
+- **No Database Changes**: Original JSON remains stored as array, conversion happens only during task execution
+- **Transparent**: Users don't see the conversion, it happens automatically
 - Ansible and Shell apps: Always use "default" key
 - Terraform apps: Use stage-specific keys, fall back to "default"
 

--- a/TERRAFORM_ARGS_IMPROVEMENT.md
+++ b/TERRAFORM_ARGS_IMPROVEMENT.md
@@ -1,0 +1,187 @@
+# Terraform Multi-Stage Arguments Support
+
+## Overview
+
+Enhanced the argument handling system to support stage-specific CLI arguments for Terraform tasks. This allows providing different arguments for different Terraform stages (init, plan, apply) which is essential for complex Terraform workflows.
+
+## What Changed
+
+### 1. LocalAppRunningArgs Structure (`db_lib/LocalApp.go`)
+
+Added support for map-based arguments alongside the existing array format:
+
+```go
+type LocalAppRunningArgs struct {
+    CliArgs         []string                // Legacy array format (backward compatible)
+    CliArgsMap      map[string][]string     // New map format for stage-specific args
+    EnvironmentVars []string
+    Inputs          map[string]string
+    TaskParams      any
+    TemplateParams  any
+    Callback        func(*os.Process)
+}
+```
+
+### 2. Argument Parsing (`services/tasks/LocalJob.go`)
+
+Added `getCLIArgsMap()` function that:
+- Attempts to parse arguments as an array first (backward compatible)
+- Falls back to map format if array parsing fails
+- Returns both array and map representations
+- Supports both Template and Task level arguments
+
+### 3. Terraform Argument Processing (`services/tasks/LocalJob.go`)
+
+Updated `getTerraformArgs()` to:
+- Return both array and map formats
+- Merge template and task arguments at the stage level
+- Apply common args (destroy, vars, secrets) to all stages
+- Auto-create "init" stage if not explicitly defined
+
+### 4. TerraformApp Enhancements (`db_lib/TerraformApp.go`)
+
+Modified Terraform execution to:
+- Accept stage-specific init args during installation
+- Use different args for plan and apply stages
+- Maintain backward compatibility with array format
+- New method `InstallRequirementsWithInitArgs()` for init customization
+
+### 5. LocalJob Orchestration (`services/tasks/LocalJob.go`)
+
+Enhanced `Run()` method to:
+- Get args before prepareRun for Terraform apps
+- Pass init-specific args during installation
+- Provide plan/apply-specific args during execution
+
+## Usage Examples
+
+### Legacy Format (Still Supported)
+
+Array format arguments apply to all stages:
+
+```json
+{
+  "arguments": ["-var", "environment=production"]
+}
+```
+
+### New Map Format
+
+Stage-specific arguments for different Terraform operations:
+
+```json
+{
+  "arguments": {
+    "init": ["-upgrade"],
+    "plan": ["-var", "foo=bar"],
+    "apply": ["-var", "foo=baz"]
+  }
+}
+```
+
+### Real-World Example
+
+Template with stage-specific configurations:
+
+```json
+{
+  "template": {
+    "arguments": {
+      "init": ["-backend-config=bucket=my-bucket"],
+      "plan": ["-out=tfplan"],
+      "apply": ["tfplan"]
+    }
+  }
+}
+```
+
+Task override combining with template args:
+
+```json
+{
+  "task": {
+    "arguments": {
+      "init": ["-reconfigure"],
+      "apply": ["-auto-approve"]
+    }
+  }
+}
+```
+
+Result: Arguments are merged per stage
+- **init**: `-backend-config=bucket=my-bucket`, `-reconfigure`
+- **plan**: `-out=tfplan`
+- **apply**: `tfplan`, `-auto-approve`
+
+## Backward Compatibility
+
+✅ **100% Backward Compatible**
+
+- Existing array format continues to work
+- No changes required to existing templates/tasks
+- Array format arguments are used for all stages when no map is provided
+- Gradual migration path available
+
+## Implementation Details
+
+### Stage-Specific Argument Flow
+
+1. **Parse Phase**: Arguments parsed as array or map from JSON
+2. **Merge Phase**: Template and task args merged at stage level
+3. **Common Args**: Environment vars, secrets, and destroy flag added to all stages
+4. **Execution Phase**: Appropriate args used for each stage (init, plan, apply)
+
+### Key Functions
+
+- `getCLIArgsMap()`: Parses both formats from JSON
+- `getTerraformArgs()`: Builds stage-specific argument maps
+- `prepareRunTerraform()`: Passes init args to Terraform installation
+- `TerraformApp.Run()`: Uses plan/apply-specific args during execution
+
+### Supported Stages
+
+- **init**: Used during `terraform init` (via InstallRequirements)
+- **plan**: Used during `terraform plan`
+- **apply**: Used during `terraform apply`
+
+Note: If using map format, unspecified stages fall back to CliArgs if available.
+
+## Testing
+
+The implementation has been validated with:
+- Successful build of entire project
+- No linter errors
+- Backward compatibility verified
+- Both array and map formats tested
+
+## Benefits
+
+1. **Flexibility**: Different args for different Terraform stages
+2. **Security**: Keep sensitive args only in specific stages
+3. **Efficiency**: Optimize each stage independently
+4. **Clarity**: Clear separation of stage-specific configurations
+5. **Compatibility**: Works alongside existing array format
+
+## Migration Path
+
+### Phase 1: Keep using array format (no changes needed)
+```json
+{"arguments": ["-var", "foo=bar"]}
+```
+
+### Phase 2: Migrate to map format for multi-stage tasks
+```json
+{"arguments": {"init": ["-upgrade"], "apply": ["-var", "foo=bar"]}}
+```
+
+### Phase 3: Leverage full stage-specific capabilities
+```json
+{
+  "arguments": {
+    "init": ["-backend-config=..."],
+    "plan": ["-out=tfplan", "-var-file=prod.tfvars"],
+    "apply": ["tfplan", "-parallelism=20"]
+  }
+}
+```
+

--- a/TERRAFORM_ARGS_IMPROVEMENT.md
+++ b/TERRAFORM_ARGS_IMPROVEMENT.md
@@ -8,12 +8,11 @@ Enhanced the argument handling system to support stage-specific CLI arguments fo
 
 ### 1. LocalAppRunningArgs Structure (`db_lib/LocalApp.go`)
 
-Added support for map-based arguments alongside the existing array format:
+Unified to use map-based arguments with "default" key for backward compatibility:
 
 ```go
 type LocalAppRunningArgs struct {
-    CliArgs         []string                // Legacy array format (backward compatible)
-    CliArgsMap      map[string][]string     // New map format for stage-specific args
+    CliArgs         map[string][]string     // Stage-specific args (e.g., "init", "apply", "default")
     EnvironmentVars []string
     Inputs          map[string]string
     TaskParams      any
@@ -22,28 +21,31 @@ type LocalAppRunningArgs struct {
 }
 ```
 
+**Key Change**: Array format arguments are automatically converted to map format with key "default".
+
 ### 2. Argument Parsing (`services/tasks/LocalJob.go`)
 
 Added `getCLIArgsMap()` function that:
 - Attempts to parse arguments as an array first (backward compatible)
+- Converts array format to map with "default" key automatically
 - Falls back to map format if array parsing fails
-- Returns both array and map representations
+- Returns map representation for all argument types
 - Supports both Template and Task level arguments
 
 ### 3. Terraform Argument Processing (`services/tasks/LocalJob.go`)
 
 Updated `getTerraformArgs()` to:
-- Return both array and map formats
+- Return map format only (unified interface)
 - Merge template and task arguments at the stage level
 - Apply common args (destroy, vars, secrets) to all stages
-- Auto-create "init" stage if not explicitly defined
+- Ensure at least "default" stage exists with common args
 
 ### 4. TerraformApp Enhancements (`db_lib/TerraformApp.go`)
 
 Modified Terraform execution to:
 - Accept stage-specific init args during installation
 - Use different args for plan and apply stages
-- Maintain backward compatibility with array format
+- Fall back to "default" key when specific stage not defined
 - New method `InstallRequirementsWithInitArgs()` for init customization
 
 ### 5. LocalJob Orchestration (`services/tasks/LocalJob.go`)
@@ -52,16 +54,26 @@ Enhanced `Run()` method to:
 - Get args before prepareRun for Terraform apps
 - Pass init-specific args during installation
 - Provide plan/apply-specific args during execution
+- Convert all args to unified map format with "default" key for non-Terraform apps
 
 ## Usage Examples
 
 ### Legacy Format (Still Supported)
 
-Array format arguments apply to all stages:
+Array format arguments are automatically converted to map with "default" key:
 
 ```json
 {
   "arguments": ["-var", "environment=production"]
+}
+```
+
+**Internally converted to:**
+```json
+{
+  "arguments": {
+    "default": ["-var", "environment=production"]
+  }
 }
 ```
 
@@ -143,8 +155,21 @@ Result: Arguments are merged per stage
 - **init**: Used during `terraform init` (via InstallRequirements)
 - **plan**: Used during `terraform plan`
 - **apply**: Used during `terraform apply`
+- **default**: Used as fallback when specific stage not defined
 
-Note: If using map format, unspecified stages fall back to CliArgs if available.
+### Stage Resolution Order (Terraform)
+
+For each stage, arguments are resolved in this order:
+1. Stage-specific key (e.g., "init", "plan", "apply")
+2. Fall back to "default" key if stage-specific not found
+3. Empty array if neither exists
+
+### Backward Compatibility Details
+
+**Array Format → Map Conversion:**
+- Array `["-var", "foo=bar"]` → Map `{"default": ["-var", "foo=bar"]}`
+- Ansible and Shell apps: Always use "default" key
+- Terraform apps: Use stage-specific keys, fall back to "default"
 
 ## Testing
 
@@ -168,13 +193,27 @@ The implementation has been validated with:
 ```json
 {"arguments": ["-var", "foo=bar"]}
 ```
+**Result:** Automatically converted to `{"default": ["-var", "foo=bar"]}` internally
 
 ### Phase 2: Migrate to map format for multi-stage tasks
 ```json
 {"arguments": {"init": ["-upgrade"], "apply": ["-var", "foo=bar"]}}
 ```
+**Result:** Uses stage-specific args for init and apply
 
-### Phase 3: Leverage full stage-specific capabilities
+### Phase 3: Mix default and stage-specific for flexibility
+```json
+{
+  "arguments": {
+    "default": ["-var", "common=value"],
+    "init": ["-upgrade"],
+    "apply": ["-parallelism=20"]
+  }
+}
+```
+**Result:** plan stage uses "default" args, init and apply use their specific args
+
+### Phase 4: Leverage full stage-specific capabilities
 ```json
 {
   "arguments": {
@@ -184,4 +223,5 @@ The implementation has been validated with:
   }
 }
 ```
+**Result:** Complete control over each stage independently
 

--- a/db_lib/AnsibleApp.go
+++ b/db_lib/AnsibleApp.go
@@ -62,7 +62,9 @@ func (t *AnsibleApp) SetLogger(logger task_logger.Logger) task_logger.Logger {
 }
 
 func (t *AnsibleApp) Run(args LocalAppRunningArgs) error {
-	return t.Playbook.RunPlaybook(args.CliArgs, args.EnvironmentVars, args.Inputs, args.Callback)
+	// Use "default" key for backward compatibility
+	cliArgs := args.CliArgs["default"]
+	return t.Playbook.RunPlaybook(cliArgs, args.EnvironmentVars, args.Inputs, args.Callback)
 }
 
 func (t *AnsibleApp) Log(msg string) {

--- a/db_lib/LocalApp.go
+++ b/db_lib/LocalApp.go
@@ -29,6 +29,7 @@ func getEnvironmentVars() []string {
 
 type LocalAppRunningArgs struct {
 	CliArgs         []string
+	CliArgsMap      map[string][]string // Stage-specific args (e.g., "init", "apply")
 	EnvironmentVars []string
 	Inputs          map[string]string
 	TaskParams      any

--- a/db_lib/LocalApp.go
+++ b/db_lib/LocalApp.go
@@ -28,8 +28,7 @@ func getEnvironmentVars() []string {
 }
 
 type LocalAppRunningArgs struct {
-	CliArgs         []string
-	CliArgsMap      map[string][]string // Stage-specific args (e.g., "init", "apply")
+	CliArgs         map[string][]string // Stage-specific args (e.g., "init", "apply", "default")
 	EnvironmentVars []string
 	Inputs          map[string]string
 	TaskParams      any

--- a/db_lib/ShellApp.go
+++ b/db_lib/ShellApp.go
@@ -109,7 +109,9 @@ func (t *ShellApp) makeShellCmd(args []string, environmentVars []string) *exec.C
 }
 
 func (t *ShellApp) Run(args LocalAppRunningArgs) error {
-	cmd := t.makeShellCmd(args.CliArgs, args.EnvironmentVars)
+	// Use "default" key for backward compatibility
+	cliArgs := args.CliArgs["default"]
+	cmd := t.makeShellCmd(cliArgs, args.EnvironmentVars)
 	t.Logger.LogCmd(cmd)
 	//cmd.Stdin = &t.reader
 	cmd.Stdin = strings.NewReader("")

--- a/db_lib/TerraformApp.go
+++ b/db_lib/TerraformApp.go
@@ -130,7 +130,7 @@ func (t *TerraformApp) SetLogger(logger task_logger.Logger) task_logger.Logger {
 	return logger
 }
 
-func (t *TerraformApp) init(environmentVars []string, keyInstaller AccessKeyInstaller, params *db.TerraformTaskParams) error {
+func (t *TerraformApp) init(environmentVars []string, keyInstaller AccessKeyInstaller, params *db.TerraformTaskParams, extraArgs []string) error {
 
 	keyInstallation, err := keyInstaller.Install(t.Inventory.SSHKey, db.AccessKeyRoleGit, t.Logger)
 	if err != nil {
@@ -148,6 +148,11 @@ func (t *TerraformApp) init(environmentVars []string, keyInstaller AccessKeyInst
 		args = append(args, "-reconfigure")
 	} else {
 		args = append(args, "-migrate-state")
+	}
+
+	// Add extra args specific to init stage
+	if extraArgs != nil {
+		args = append(args, extraArgs...)
 	}
 
 	cmd := t.makeCmd(t.Name, args, environmentVars)
@@ -230,7 +235,16 @@ func (t *TerraformApp) Clear() {
 	}
 }
 
+type TerraformInstallRequirementsArgs struct {
+	LocalAppInstallingArgs
+	InitArgs []string // Stage-specific args for init
+}
+
 func (t *TerraformApp) InstallRequirements(args LocalAppInstallingArgs) (err error) {
+	return t.InstallRequirementsWithInitArgs(args, nil)
+}
+
+func (t *TerraformApp) InstallRequirementsWithInitArgs(args LocalAppInstallingArgs, initArgs []string) (err error) {
 
 	tpl := args.TplParams.(*db.TerraformTemplateParams)
 	p := args.Params.(*db.TerraformTaskParams)
@@ -248,7 +262,7 @@ func (t *TerraformApp) InstallRequirements(args LocalAppInstallingArgs) (err err
 		}
 	}
 
-	if err = t.init(args.EnvironmentVars, args.Installer, p); err != nil {
+	if err = t.init(args.EnvironmentVars, args.Installer, p, initArgs); err != nil {
 		return
 	}
 
@@ -317,7 +331,32 @@ func (t *TerraformApp) Apply(args []string, environmentVars []string, inputs map
 }
 
 func (t *TerraformApp) Run(args LocalAppRunningArgs) error {
-	err := t.Plan(args.CliArgs, args.EnvironmentVars, args.Inputs, args.Callback)
+	// Determine which args to use for plan and apply stages
+	var planArgs []string
+	var applyArgs []string
+
+	if args.CliArgsMap != nil && len(args.CliArgsMap) > 0 {
+		// Use stage-specific args from map
+		if pArgs, ok := args.CliArgsMap["plan"]; ok {
+			planArgs = pArgs
+		} else {
+			// Fall back to CliArgs if no plan-specific args
+			planArgs = args.CliArgs
+		}
+
+		if aArgs, ok := args.CliArgsMap["apply"]; ok {
+			applyArgs = aArgs
+		} else {
+			// Fall back to CliArgs if no apply-specific args
+			applyArgs = args.CliArgs
+		}
+	} else {
+		// Use legacy CliArgs for backward compatibility
+		planArgs = args.CliArgs
+		applyArgs = args.CliArgs
+	}
+
+	err := t.Plan(planArgs, args.EnvironmentVars, args.Inputs, args.Callback)
 	if err != nil {
 		return err
 	}
@@ -332,7 +371,7 @@ func (t *TerraformApp) Run(args LocalAppRunningArgs) error {
 
 	if tplParams.AutoApprove || tplParams.AllowAutoApprove && params.AutoApprove {
 		t.Logger.SetStatus(task_logger.TaskRunningStatus)
-		return t.Apply(args.CliArgs, args.EnvironmentVars, args.Inputs, args.Callback)
+		return t.Apply(applyArgs, args.EnvironmentVars, args.Inputs, args.Callback)
 	}
 
 	t.Logger.SetStatus(task_logger.TaskWaitingConfirmation)
@@ -351,7 +390,7 @@ func (t *TerraformApp) Run(args LocalAppRunningArgs) error {
 		t.Logger.SetStatus(task_logger.TaskFailStatus)
 	case task_logger.TaskConfirmed:
 		t.Logger.SetStatus(task_logger.TaskRunningStatus)
-		return t.Apply(args.CliArgs, args.EnvironmentVars, args.Inputs, args.Callback)
+		return t.Apply(applyArgs, args.EnvironmentVars, args.Inputs, args.Callback)
 	}
 
 	return nil

--- a/db_lib/TerraformApp.go
+++ b/db_lib/TerraformApp.go
@@ -338,6 +338,8 @@ func (t *TerraformApp) Run(args LocalAppRunningArgs) error {
 	// Use stage-specific args from map, with "default" fallback
 	if pArgs, ok := args.CliArgs["plan"]; ok {
 		planArgs = pArgs
+	} else if aArgs, ok := args.CliArgs["apply"]; ok {
+		applyArgs = aArgs
 	} else if defaultArgs, ok := args.CliArgs["default"]; ok {
 		planArgs = defaultArgs
 	}

--- a/db_lib/TerraformApp.go
+++ b/db_lib/TerraformApp.go
@@ -335,25 +335,17 @@ func (t *TerraformApp) Run(args LocalAppRunningArgs) error {
 	var planArgs []string
 	var applyArgs []string
 
-	if args.CliArgsMap != nil && len(args.CliArgsMap) > 0 {
-		// Use stage-specific args from map
-		if pArgs, ok := args.CliArgsMap["plan"]; ok {
-			planArgs = pArgs
-		} else {
-			// Fall back to CliArgs if no plan-specific args
-			planArgs = args.CliArgs
-		}
+	// Use stage-specific args from map, with "default" fallback
+	if pArgs, ok := args.CliArgs["plan"]; ok {
+		planArgs = pArgs
+	} else if defaultArgs, ok := args.CliArgs["default"]; ok {
+		planArgs = defaultArgs
+	}
 
-		if aArgs, ok := args.CliArgsMap["apply"]; ok {
-			applyArgs = aArgs
-		} else {
-			// Fall back to CliArgs if no apply-specific args
-			applyArgs = args.CliArgs
-		}
-	} else {
-		// Use legacy CliArgs for backward compatibility
-		planArgs = args.CliArgs
-		applyArgs = args.CliArgs
+	if aArgs, ok := args.CliArgs["apply"]; ok {
+		applyArgs = aArgs
+	} else if defaultArgs, ok := args.CliArgs["default"]; ok {
+		applyArgs = defaultArgs
 	}
 
 	err := t.Plan(planArgs, args.EnvironmentVars, args.Inputs, args.Callback)

--- a/examples/terraform_args_example.json
+++ b/examples/terraform_args_example.json
@@ -1,0 +1,56 @@
+{
+  "description": "Example of Terraform multi-stage arguments format",
+  "examples": [
+    {
+      "name": "Legacy array format (backward compatible)",
+      "arguments": ["-var", "environment=production"]
+    },
+    {
+      "name": "New map format with stage-specific args",
+      "arguments": {
+        "init": ["-upgrade"],
+        "plan": ["-var", "environment=production"],
+        "apply": ["-var", "environment=production", "-parallelism=10"]
+      }
+    },
+    {
+      "name": "Terraform with backend configuration",
+      "arguments": {
+        "init": [
+          "-backend-config=bucket=my-terraform-state",
+          "-backend-config=key=prod/terraform.tfstate"
+        ],
+        "plan": ["-out=tfplan"],
+        "apply": ["tfplan"]
+      }
+    },
+    {
+      "name": "Multi-environment setup",
+      "arguments": {
+        "init": ["-reconfigure"],
+        "plan": [
+          "-var-file=environments/production.tfvars",
+          "-out=tfplan"
+        ],
+        "apply": [
+          "tfplan",
+          "-auto-approve"
+        ]
+      }
+    },
+    {
+      "name": "Minimal init-only customization",
+      "arguments": {
+        "init": ["-upgrade"]
+      },
+      "note": "Plan and apply will use common arguments only (vars, secrets, etc.)"
+    }
+  ],
+  "notes": [
+    "Common arguments like -var, -destroy, and environment secrets are automatically added to all stages",
+    "If a stage is not defined in the map, it will use CliArgs if available",
+    "Template arguments and Task arguments are merged at the stage level",
+    "Array format applies arguments to all stages (backward compatible behavior)"
+  ]
+}
+

--- a/examples/terraform_args_example.json
+++ b/examples/terraform_args_example.json
@@ -1,9 +1,14 @@
 {
   "description": "Example of Terraform multi-stage arguments format",
+  "architecture_note": "Array format is automatically converted to map with 'default' key internally",
   "examples": [
     {
       "name": "Legacy array format (backward compatible)",
-      "arguments": ["-var", "environment=production"]
+      "arguments": ["-var", "environment=production"],
+      "internal_representation": {
+        "default": ["-var", "environment=production"]
+      },
+      "behavior": "All stages (init, plan, apply) use the 'default' key args"
     },
     {
       "name": "New map format with stage-specific args",
@@ -11,7 +16,17 @@
         "init": ["-upgrade"],
         "plan": ["-var", "environment=production"],
         "apply": ["-var", "environment=production", "-parallelism=10"]
-      }
+      },
+      "behavior": "Each stage uses its specific args"
+    },
+    {
+      "name": "Mix of default and stage-specific",
+      "arguments": {
+        "default": ["-var", "common=value"],
+        "init": ["-upgrade"],
+        "apply": ["-parallelism=20"]
+      },
+      "behavior": "init uses its args, plan uses 'default', apply uses its args"
     },
     {
       "name": "Terraform with backend configuration",
@@ -39,18 +54,21 @@
       }
     },
     {
-      "name": "Minimal init-only customization",
+      "name": "Minimal init-only customization with default fallback",
       "arguments": {
+        "default": ["-var", "environment=prod"],
         "init": ["-upgrade"]
       },
-      "note": "Plan and apply will use common arguments only (vars, secrets, etc.)"
+      "behavior": "init uses '-upgrade', plan and apply use 'default' args"
     }
   ],
   "notes": [
+    "Array format is automatically converted to map with 'default' key",
     "Common arguments like -var, -destroy, and environment secrets are automatically added to all stages",
-    "If a stage is not defined in the map, it will use CliArgs if available",
+    "Stage resolution order: specific stage key -> 'default' key -> empty array",
     "Template arguments and Task arguments are merged at the stage level",
-    "Array format applies arguments to all stages (backward compatible behavior)"
+    "Ansible and Shell apps always use the 'default' key",
+    "Terraform apps can use stage-specific keys (init, plan, apply) with 'default' fallback"
   ]
 }
 

--- a/examples/terraform_args_example.json
+++ b/examples/terraform_args_example.json
@@ -1,6 +1,6 @@
 {
   "description": "Example of Terraform multi-stage arguments format",
-  "architecture_note": "Array format is automatically converted to map with 'default' key internally",
+  "architecture_note": "Array format is automatically converted to map with 'default' key at runtime during task execution",
   "examples": [
     {
       "name": "Legacy array format (backward compatible)",
@@ -63,7 +63,7 @@
     }
   ],
   "notes": [
-    "Array format is automatically converted to map with 'default' key",
+    "Array format is automatically converted to map with 'default' key at runtime (original JSON in database remains unchanged)",
     "Common arguments like -var, -destroy, and environment secrets are automatically added to all stages",
     "Stage resolution order: specific stage key -> 'default' key -> empty array",
     "Template arguments and Task arguments are merged at the stage level",

--- a/services/tasks/LocalJob.go
+++ b/services/tasks/LocalJob.go
@@ -309,8 +309,11 @@ func (t *LocalJob) getTerraformArgs(username string, incomingVersion *string) (a
 		}
 	}
 
-	// Add common args to each stage
+	// Add common args to each stage except init
 	for stage := range argsMap {
+		if stage == "init" {
+			continue
+		}
 		// Prepend destroy args
 		combined := append([]string{}, destroyArgs...)
 		combined = append(combined, argsMap[stage]...)

--- a/services/tasks/LocalJob.go
+++ b/services/tasks/LocalJob.go
@@ -244,9 +244,8 @@ func (t *LocalJob) getShellArgs(username string, incomingVersion *string) (args 
 }
 
 // nolint: gocyclo
-func (t *LocalJob) getTerraformArgs(username string, incomingVersion *string) (args []string, argsMap map[string][]string, err error) {
+func (t *LocalJob) getTerraformArgs(username string, incomingVersion *string) (argsMap map[string][]string, err error) {
 
-	args = []string{}
 	argsMap = make(map[string][]string)
 
 	extraVars, err := t.getEnvironmentExtraVars(username, incomingVersion)
@@ -278,7 +277,7 @@ func (t *LocalJob) getTerraformArgs(username string, incomingVersion *string) (a
 		varArgs = append(varArgs, "-var", fmt.Sprintf("%s=%s", name, value))
 	}
 
-	templateArgs, taskArgs, templateArgsMap, taskArgsMap, err := t.getCLIArgsMap()
+	templateArgsMap, taskArgsMap, err := t.getCLIArgsMap()
 	if err != nil {
 		t.Log(err.Error())
 		return
@@ -293,45 +292,36 @@ func (t *LocalJob) getTerraformArgs(username string, incomingVersion *string) (a
 		secretArgs = append(secretArgs, "-var", fmt.Sprintf("%s=%s", secret.Name, secret.Secret))
 	}
 
-	// If we have map format, use it for stage-specific args
-	if templateArgsMap != nil || taskArgsMap != nil {
-		// Merge template and task args maps
-		argsMap = make(map[string][]string)
-		
-		if templateArgsMap != nil {
-			for stage, stageArgs := range templateArgsMap {
+	// Merge template and task args maps
+	if templateArgsMap != nil {
+		for stage, stageArgs := range templateArgsMap {
+			argsMap[stage] = append([]string{}, stageArgs...)
+		}
+	}
+	
+	if taskArgsMap != nil {
+		for stage, stageArgs := range taskArgsMap {
+			if existing, ok := argsMap[stage]; ok {
+				argsMap[stage] = append(existing, stageArgs...)
+			} else {
 				argsMap[stage] = append([]string{}, stageArgs...)
 			}
 		}
-		
-		if taskArgsMap != nil {
-			for stage, stageArgs := range taskArgsMap {
-				if existing, ok := argsMap[stage]; ok {
-					argsMap[stage] = append(existing, stageArgs...)
-				} else {
-					argsMap[stage] = append([]string{}, stageArgs...)
-				}
-			}
-		}
+	}
 
-		// Add common args to each stage
-		for stage := range argsMap {
-			argsMap[stage] = append(destroyArgs, argsMap[stage]...)
-			argsMap[stage] = append(argsMap[stage], varArgs...)
-			argsMap[stage] = append(argsMap[stage], secretArgs...)
-		}
+	// Add common args to each stage
+	for stage := range argsMap {
+		// Prepend destroy args
+		combined := append([]string{}, destroyArgs...)
+		combined = append(combined, argsMap[stage]...)
+		combined = append(combined, varArgs...)
+		combined = append(combined, secretArgs...)
+		argsMap[stage] = combined
+	}
 
-		// If no "init" stage defined, create one with common args
-		if _, ok := argsMap["init"]; !ok {
-			argsMap["init"] = append(append([]string{}, destroyArgs...), append(varArgs, secretArgs...)...)
-		}
-	} else {
-		// Fall back to array format (backward compatibility)
-		args = append(args, destroyArgs...)
-		args = append(args, varArgs...)
-		args = append(args, templateArgs...)
-		args = append(args, taskArgs...)
-		args = append(args, secretArgs...)
+	// Ensure we have at least a "default" stage with common args if no args specified
+	if len(argsMap) == 0 {
+		argsMap["default"] = append(append([]string{}, destroyArgs...), append(varArgs, secretArgs...)...)
 	}
 
 	return
@@ -556,11 +546,13 @@ func (t *LocalJob) getCLIArgs() (templateArgs []string, taskArgs []string, err e
 }
 
 // getCLIArgsMap returns args that support both array and map formats
-// Returns: templateArgs (array), taskArgs (array), templateArgsMap (map), taskArgsMap (map), err
-func (t *LocalJob) getCLIArgsMap() (templateArgs []string, taskArgs []string, templateArgsMap map[string][]string, taskArgsMap map[string][]string, err error) {
+// Array format is converted to map with "default" key for backward compatibility
+// Returns: templateArgsMap (map), taskArgsMap (map), err
+func (t *LocalJob) getCLIArgsMap() (templateArgsMap map[string][]string, taskArgsMap map[string][]string, err error) {
 
 	if t.Template.Arguments != nil {
 		// Try to unmarshal as array first
+		var templateArgs []string
 		err = json.Unmarshal([]byte(*t.Template.Arguments), &templateArgs)
 		if err != nil {
 			// If array fails, try map format
@@ -570,11 +562,17 @@ func (t *LocalJob) getCLIArgsMap() (templateArgs []string, taskArgs []string, te
 				return
 			}
 			err = nil // Clear error since map parsing succeeded
+		} else {
+			// Array format: convert to map with "default" key
+			templateArgsMap = map[string][]string{
+				"default": templateArgs,
+			}
 		}
 	}
 
 	if t.Template.AllowOverrideArgsInTask && t.Task.Arguments != nil {
 		// Try to unmarshal as array first
+		var taskArgs []string
 		err = json.Unmarshal([]byte(*t.Task.Arguments), &taskArgs)
 		if err != nil {
 			// If array fails, try map format
@@ -584,6 +582,11 @@ func (t *LocalJob) getCLIArgsMap() (templateArgs []string, taskArgs []string, te
 				return
 			}
 			err = nil // Clear error since map parsing succeeded
+		} else {
+			// Array format: convert to map with "default" key
+			taskArgsMap = map[string][]string{
+				"default": taskArgs,
+			}
 		}
 	}
 
@@ -654,19 +657,14 @@ func (t *LocalJob) Run(username string, incomingVersion *string, alias string) (
 	}
 
 	// For Terraform apps, get args first so we can pass init args to prepareRun
-	var args []string
 	var argsMap map[string][]string
 	var inputs map[string]string
 
 	if t.Template.App.IsTerraform() {
-		args, argsMap, err = t.getTerraformArgs(username, incomingVersion)
+		argsMap, err = t.getTerraformArgs(username, incomingVersion)
 		if err != nil {
 			return
 		}
-	}
-
-	// Call prepareRun with init args for Terraform
-	if t.Template.App.IsTerraform() && argsMap != nil {
 		// Use Terraform-specific prepareRun with init args
 		if tfApp, ok := t.App.(*db_lib.TerraformApp); ok {
 			err = t.prepareRunTerraform(tfApp, db_lib.LocalAppInstallingArgs{
@@ -702,12 +700,15 @@ func (t *LocalJob) Run(username string, incomingVersion *string, alias string) (
 	}
 
 	// Get args for non-Terraform apps
+	var args []string
 	switch t.Template.App {
 	case db.AppAnsible:
 		args, inputs, err = t.getPlaybookArgs(username, incomingVersion)
 		if err != nil {
 			return
 		}
+		// Convert to map format with "default" key
+		argsMap = map[string][]string{"default": args}
 	case db.AppTerraform, db.AppTofu, db.AppTerragrunt:
 		// Already got args earlier for Terraform
 	default:
@@ -715,6 +716,8 @@ func (t *LocalJob) Run(username string, incomingVersion *string, alias string) (
 		if err != nil {
 			return
 		}
+		// Convert to map format with "default" key
+		argsMap = map[string][]string{"default": args}
 	}
 
 	if t.Inventory.SSHKey.Type == db.AccessKeySSH && t.Inventory.SSHKeyID != nil {
@@ -744,8 +747,7 @@ func (t *LocalJob) Run(username string, incomingVersion *string, alias string) (
 	}
 
 	return t.App.Run(db_lib.LocalAppRunningArgs{
-		CliArgs:         args,
-		CliArgsMap:      argsMap,
+		CliArgs:         argsMap,
 		EnvironmentVars: environmentVariables,
 		Inputs:          inputs,
 		TaskParams:      params,

--- a/services/tasks/LocalJob.go
+++ b/services/tasks/LocalJob.go
@@ -309,6 +309,10 @@ func (t *LocalJob) getTerraformArgs(username string, incomingVersion *string) (a
 		}
 	}
 
+	if len(argsMap) == 0 {
+		argsMap["default"] = []string{}
+	}
+
 	// Add common args to each stage except init
 	for stage := range argsMap {
 		if stage == "init" {
@@ -320,11 +324,6 @@ func (t *LocalJob) getTerraformArgs(username string, incomingVersion *string) (a
 		combined = append(combined, varArgs...)
 		combined = append(combined, secretArgs...)
 		argsMap[stage] = combined
-	}
-
-	// Ensure we have at least a "default" stage with common args if no args specified
-	if len(argsMap) == 0 {
-		argsMap["default"] = append(append([]string{}, destroyArgs...), append(varArgs, secretArgs...)...)
 	}
 
 	return

--- a/services/tasks/LocalJob.go
+++ b/services/tasks/LocalJob.go
@@ -244,9 +244,10 @@ func (t *LocalJob) getShellArgs(username string, incomingVersion *string) (args 
 }
 
 // nolint: gocyclo
-func (t *LocalJob) getTerraformArgs(username string, incomingVersion *string) (args []string, err error) {
+func (t *LocalJob) getTerraformArgs(username string, incomingVersion *string) (args []string, argsMap map[string][]string, err error) {
 
 	args = []string{}
+	argsMap = make(map[string][]string)
 
 	extraVars, err := t.getEnvironmentExtraVars(username, incomingVersion)
 
@@ -262,31 +263,75 @@ func (t *LocalJob) getTerraformArgs(username string, incomingVersion *string) (a
 		return
 	}
 
+	// Common args for destroy flag
+	destroyArgs := []string{}
 	if params.Destroy {
-		args = append(args, "-destroy")
+		destroyArgs = append(destroyArgs, "-destroy")
 	}
 
+	// Common args for environment variables
+	varArgs := []string{}
 	for name, value := range extraVars {
 		if name == "semaphore_vars" {
 			continue
 		}
-		args = append(args, "-var", fmt.Sprintf("%s=%s", name, value))
+		varArgs = append(varArgs, "-var", fmt.Sprintf("%s=%s", name, value))
 	}
 
-	templateArgs, taskArgs, err := t.getCLIArgs()
+	templateArgs, taskArgs, templateArgsMap, taskArgsMap, err := t.getCLIArgsMap()
 	if err != nil {
 		t.Log(err.Error())
 		return
 	}
 
-	args = append(args, templateArgs...)
-	args = append(args, taskArgs...)
-
+	// Common args for environment secrets
+	secretArgs := []string{}
 	for _, secret := range t.Environment.Secrets {
 		if secret.Type != db.EnvironmentSecretVar {
 			continue
 		}
-		args = append(args, "-var", fmt.Sprintf("%s=%s", secret.Name, secret.Secret))
+		secretArgs = append(secretArgs, "-var", fmt.Sprintf("%s=%s", secret.Name, secret.Secret))
+	}
+
+	// If we have map format, use it for stage-specific args
+	if templateArgsMap != nil || taskArgsMap != nil {
+		// Merge template and task args maps
+		argsMap = make(map[string][]string)
+		
+		if templateArgsMap != nil {
+			for stage, stageArgs := range templateArgsMap {
+				argsMap[stage] = append([]string{}, stageArgs...)
+			}
+		}
+		
+		if taskArgsMap != nil {
+			for stage, stageArgs := range taskArgsMap {
+				if existing, ok := argsMap[stage]; ok {
+					argsMap[stage] = append(existing, stageArgs...)
+				} else {
+					argsMap[stage] = append([]string{}, stageArgs...)
+				}
+			}
+		}
+
+		// Add common args to each stage
+		for stage := range argsMap {
+			argsMap[stage] = append(destroyArgs, argsMap[stage]...)
+			argsMap[stage] = append(argsMap[stage], varArgs...)
+			argsMap[stage] = append(argsMap[stage], secretArgs...)
+		}
+
+		// If no "init" stage defined, create one with common args
+		if _, ok := argsMap["init"]; !ok {
+			argsMap["init"] = append(append([]string{}, destroyArgs...), append(varArgs, secretArgs...)...)
+		}
+	} else {
+		// Fall back to array format (backward compatibility)
+		args = append(args, destroyArgs...)
+		args = append(args, varArgs...)
+		args = append(args, templateArgs...)
+		args = append(args, taskArgs...)
+		args = append(args, secretArgs...)
 	}
 
 	return
@@ -510,6 +555,41 @@ func (t *LocalJob) getCLIArgs() (templateArgs []string, taskArgs []string, err e
 	return
 }
 
+// getCLIArgsMap returns args that support both array and map formats
+// Returns: templateArgs (array), taskArgs (array), templateArgsMap (map), taskArgsMap (map), err
+func (t *LocalJob) getCLIArgsMap() (templateArgs []string, taskArgs []string, templateArgsMap map[string][]string, taskArgsMap map[string][]string, err error) {
+
+	if t.Template.Arguments != nil {
+		// Try to unmarshal as array first
+		err = json.Unmarshal([]byte(*t.Template.Arguments), &templateArgs)
+		if err != nil {
+			// If array fails, try map format
+			err = json.Unmarshal([]byte(*t.Template.Arguments), &templateArgsMap)
+			if err != nil {
+				err = fmt.Errorf("invalid format of the template extra arguments, must be valid JSON array or map")
+				return
+			}
+			err = nil // Clear error since map parsing succeeded
+		}
+	}
+
+	if t.Template.AllowOverrideArgsInTask && t.Task.Arguments != nil {
+		// Try to unmarshal as array first
+		err = json.Unmarshal([]byte(*t.Task.Arguments), &taskArgs)
+		if err != nil {
+			// If array fails, try map format
+			err = json.Unmarshal([]byte(*t.Task.Arguments), &taskArgsMap)
+			if err != nil {
+				err = fmt.Errorf("invalid format of the task extra arguments, must be valid JSON array or map")
+				return
+			}
+			err = nil // Clear error since map parsing succeeded
+		}
+	}
+
+	return
+}
+
 func (t *LocalJob) getTemplateParams() (any, error) {
 	var params any
 	switch t.Template.App {
@@ -573,31 +653,68 @@ func (t *LocalJob) Run(username string, incomingVersion *string, alias string) (
 		environmentVariables = append(environmentVariables, "TF_HTTP_ADDRESS="+util.GetPublicAliasURL("terraform", alias))
 	}
 
-	err = t.prepareRun(db_lib.LocalAppInstallingArgs{
-		EnvironmentVars: environmentVariables,
-		TplParams:       tplParams,
-		Params:          params,
-		Installer:       t.KeyInstaller,
-	})
-
-	if err != nil {
-		return err
-	}
-
+	// For Terraform apps, get args first so we can pass init args to prepareRun
 	var args []string
+	var argsMap map[string][]string
 	var inputs map[string]string
 
+	if t.Template.App.IsTerraform() {
+		args, argsMap, err = t.getTerraformArgs(username, incomingVersion)
+		if err != nil {
+			return
+		}
+	}
+
+	// Call prepareRun with init args for Terraform
+	if t.Template.App.IsTerraform() && argsMap != nil {
+		// Use Terraform-specific prepareRun with init args
+		if tfApp, ok := t.App.(*db_lib.TerraformApp); ok {
+			err = t.prepareRunTerraform(tfApp, db_lib.LocalAppInstallingArgs{
+				EnvironmentVars: environmentVariables,
+				TplParams:       tplParams,
+				Params:          params,
+				Installer:       t.KeyInstaller,
+			}, argsMap["init"])
+			if err != nil {
+				return err
+			}
+		} else {
+			err = t.prepareRun(db_lib.LocalAppInstallingArgs{
+				EnvironmentVars: environmentVariables,
+				TplParams:       tplParams,
+				Params:          params,
+				Installer:       t.KeyInstaller,
+			})
+			if err != nil {
+				return err
+			}
+		}
+	} else {
+		err = t.prepareRun(db_lib.LocalAppInstallingArgs{
+			EnvironmentVars: environmentVariables,
+			TplParams:       tplParams,
+			Params:          params,
+			Installer:       t.KeyInstaller,
+		})
+		if err != nil {
+			return err
+		}
+	}
+
+	// Get args for non-Terraform apps
 	switch t.Template.App {
 	case db.AppAnsible:
 		args, inputs, err = t.getPlaybookArgs(username, incomingVersion)
+		if err != nil {
+			return
+		}
 	case db.AppTerraform, db.AppTofu, db.AppTerragrunt:
-		args, err = t.getTerraformArgs(username, incomingVersion)
+		// Already got args earlier for Terraform
 	default:
 		args, err = t.getShellArgs(username, incomingVersion)
-	}
-
-	if err != nil {
-		return
+		if err != nil {
+			return
+		}
 	}
 
 	if t.Inventory.SSHKey.Type == db.AccessKeySSH && t.Inventory.SSHKeyID != nil {
@@ -628,6 +745,7 @@ func (t *LocalJob) Run(username string, incomingVersion *string, alias string) (
 
 	return t.App.Run(db_lib.LocalAppRunningArgs{
 		CliArgs:         args,
+		CliArgsMap:      argsMap,
 		EnvironmentVars: environmentVariables,
 		Inputs:          inputs,
 		TaskParams:      params,
@@ -680,6 +798,60 @@ func (t *LocalJob) prepareRun(installingArgs db_lib.LocalAppInstallingArgs) erro
 	}
 
 	if err := t.App.InstallRequirements(installingArgs); err != nil {
+		t.Log("Failed to install requirements: " + err.Error())
+		return err
+	}
+
+	if err := t.installVaultKeyFiles(); err != nil {
+		t.Log("Failed to install vault password files: " + err.Error())
+		return err
+	}
+
+	return nil
+}
+
+func (t *LocalJob) prepareRunTerraform(tfApp *db_lib.TerraformApp, installingArgs db_lib.LocalAppInstallingArgs, initArgs []string) error {
+
+	t.Log("Preparing: " + strconv.Itoa(t.Task.ID))
+
+	if err := checkTmpDir(util.Config.GetProjectTmpDir(t.Template.ProjectID)); err != nil {
+		t.Log("Creating tmp dir failed: " + err.Error())
+		return err
+	}
+
+	// Override git branch from template if set
+	if t.Template.GitBranch != nil && *t.Template.GitBranch != "" {
+		t.Repository.GitBranch = *t.Template.GitBranch
+	}
+
+	// Override git branch from task if set
+	if t.Task.GitBranch != nil && *t.Task.GitBranch != "" {
+		t.Repository.GitBranch = *t.Task.GitBranch
+	}
+
+	if t.Repository.GetType() == db.RepositoryLocal {
+		if _, err := os.Stat(t.Repository.GitURL); err != nil {
+			t.Log("Failed in finding static repository at " + t.Repository.GitURL + ": " + err.Error())
+			return err
+		}
+	} else {
+		if err := t.updateRepository(); err != nil {
+			t.Log("Failed updating repository: " + err.Error())
+			return err
+		}
+		if err := t.checkoutRepository(); err != nil {
+			t.Log("Failed to checkout repository to required commit: " + err.Error())
+			return err
+		}
+	}
+
+	if err := t.installInventory(); err != nil {
+		t.Log("Failed to install inventory: " + err.Error())
+		return err
+	}
+
+	// Call Terraform-specific install with init args
+	if err := tfApp.InstallRequirementsWithInitArgs(installingArgs, initArgs); err != nil {
 		t.Log("Failed to install requirements: " + err.Error())
 		return err
 	}

--- a/services/tasks/LocalJob.go
+++ b/services/tasks/LocalJob.go
@@ -545,10 +545,10 @@ func (t *LocalJob) getCLIArgs() (templateArgs []string, taskArgs []string, err e
 	return
 }
 
-// convertArgsJSONIfArray converts array format JSON to map format with "default" key and returns the result
-func convertArgsJSONIfArray(argsJSON string) (string, error) {
+// convertArgsJSONIfArray converts array format JSON to map format with "default" key and returns the parsed result
+func convertArgsJSONIfArray(argsJSON string) (map[string][]string, error) {
 	if argsJSON == "" {
-		return argsJSON, nil
+		return nil, nil
 	}
 
 	// Try to parse as array first
@@ -558,20 +558,16 @@ func convertArgsJSONIfArray(argsJSON string) (string, error) {
 		mapArgs := map[string][]string{
 			"default": arr,
 		}
-		convertedJSON, err := json.Marshal(mapArgs)
-		if err != nil {
-			return "", fmt.Errorf("failed to convert array to map format: %v", err)
-		}
-		return string(convertedJSON), nil
+		return mapArgs, nil
 	}
 
 	// If not an array, verify it's a valid map format
 	var mapArgs map[string][]string
 	if err := json.Unmarshal([]byte(argsJSON), &mapArgs); err != nil {
-		return "", fmt.Errorf("invalid format of arguments, must be valid JSON array or map: %v", err)
+		return nil, fmt.Errorf("invalid format of arguments, must be valid JSON array or map: %v", err)
 	}
 
-	return argsJSON, nil
+	return mapArgs, nil
 }
 
 // getCLIArgsMap returns args that support both array and map formats
@@ -581,36 +577,17 @@ func (t *LocalJob) getCLIArgsMap() (templateArgsMap map[string][]string, taskArg
 
 	// Convert template arguments if needed
 	if t.Template.Arguments != nil {
-		converted, err := convertArgsJSONIfArray(*t.Template.Arguments)
+		templateArgsMap, err = convertArgsJSONIfArray(*t.Template.Arguments)
 		if err != nil {
 			return nil, nil, err
 		}
-		t.Template.Arguments = &converted
 	}
 
 	// Convert task arguments if needed
 	if t.Template.AllowOverrideArgsInTask && t.Task.Arguments != nil {
-		converted, err := convertArgsJSONIfArray(*t.Task.Arguments)
+		taskArgsMap, err = convertArgsJSONIfArray(*t.Task.Arguments)
 		if err != nil {
 			return nil, nil, err
-		}
-		t.Task.Arguments = &converted
-	}
-
-	// Now parse as map format (both should be maps after conversion)
-	if t.Template.Arguments != nil {
-		err = json.Unmarshal([]byte(*t.Template.Arguments), &templateArgsMap)
-		if err != nil {
-			err = fmt.Errorf("failed to parse template arguments as map: %v", err)
-			return
-		}
-	}
-
-	if t.Template.AllowOverrideArgsInTask && t.Task.Arguments != nil {
-		err = json.Unmarshal([]byte(*t.Task.Arguments), &taskArgsMap)
-		if err != nil {
-			err = fmt.Errorf("failed to parse task arguments as map: %v", err)
-			return
 		}
 	}
 

--- a/services/tasks/LocalJob.go
+++ b/services/tasks/LocalJob.go
@@ -545,34 +545,33 @@ func (t *LocalJob) getCLIArgs() (templateArgs []string, taskArgs []string, err e
 	return
 }
 
-// convertArgsJSONIfArray converts array format JSON to map format with "default" key
-func convertArgsJSONIfArray(argsJSON *string) error {
-	if argsJSON == nil || *argsJSON == "" {
-		return nil
+// convertArgsJSONIfArray converts array format JSON to map format with "default" key and returns the result
+func convertArgsJSONIfArray(argsJSON string) (string, error) {
+	if argsJSON == "" {
+		return argsJSON, nil
 	}
 
 	// Try to parse as array first
 	var arr []string
-	if err := json.Unmarshal([]byte(*argsJSON), &arr); err == nil {
+	if err := json.Unmarshal([]byte(argsJSON), &arr); err == nil {
 		// It's an array, convert to map format
 		mapArgs := map[string][]string{
 			"default": arr,
 		}
 		convertedJSON, err := json.Marshal(mapArgs)
 		if err != nil {
-			return fmt.Errorf("failed to convert array to map format: %v", err)
+			return "", fmt.Errorf("failed to convert array to map format: %v", err)
 		}
-		*argsJSON = string(convertedJSON)
-		return nil
+		return string(convertedJSON), nil
 	}
 
 	// If not an array, verify it's a valid map format
 	var mapArgs map[string][]string
-	if err := json.Unmarshal([]byte(*argsJSON), &mapArgs); err != nil {
-		return fmt.Errorf("invalid format of arguments, must be valid JSON array or map: %v", err)
+	if err := json.Unmarshal([]byte(argsJSON), &mapArgs); err != nil {
+		return "", fmt.Errorf("invalid format of arguments, must be valid JSON array or map: %v", err)
 	}
 
-	return nil
+	return argsJSON, nil
 }
 
 // getCLIArgsMap returns args that support both array and map formats
@@ -581,15 +580,21 @@ func convertArgsJSONIfArray(argsJSON *string) error {
 func (t *LocalJob) getCLIArgsMap() (templateArgsMap map[string][]string, taskArgsMap map[string][]string, err error) {
 
 	// Convert template arguments if needed
-	if err = convertArgsJSONIfArray(t.Template.Arguments); err != nil {
-		return
+	if t.Template.Arguments != nil {
+		converted, err := convertArgsJSONIfArray(*t.Template.Arguments)
+		if err != nil {
+			return nil, nil, err
+		}
+		t.Template.Arguments = &converted
 	}
 
 	// Convert task arguments if needed
-	if t.Template.AllowOverrideArgsInTask {
-		if err = convertArgsJSONIfArray(t.Task.Arguments); err != nil {
-			return
+	if t.Template.AllowOverrideArgsInTask && t.Task.Arguments != nil {
+		converted, err := convertArgsJSONIfArray(*t.Task.Arguments)
+		if err != nil {
+			return nil, nil, err
 		}
+		t.Task.Arguments = &converted
 	}
 
 	// Now parse as map format (both should be maps after conversion)

--- a/services/tasks/LocalJob.go
+++ b/services/tasks/LocalJob.go
@@ -298,7 +298,7 @@ func (t *LocalJob) getTerraformArgs(username string, incomingVersion *string) (a
 			argsMap[stage] = append([]string{}, stageArgs...)
 		}
 	}
-	
+
 	if taskArgsMap != nil {
 		for stage, stageArgs := range taskArgsMap {
 			if existing, ok := argsMap[stage]; ok {
@@ -545,48 +545,67 @@ func (t *LocalJob) getCLIArgs() (templateArgs []string, taskArgs []string, err e
 	return
 }
 
+// convertArgsJSONIfArray converts array format JSON to map format with "default" key
+func convertArgsJSONIfArray(argsJSON *string) error {
+	if argsJSON == nil || *argsJSON == "" {
+		return nil
+	}
+
+	// Try to parse as array first
+	var arr []string
+	if err := json.Unmarshal([]byte(*argsJSON), &arr); err == nil {
+		// It's an array, convert to map format
+		mapArgs := map[string][]string{
+			"default": arr,
+		}
+		convertedJSON, err := json.Marshal(mapArgs)
+		if err != nil {
+			return fmt.Errorf("failed to convert array to map format: %v", err)
+		}
+		*argsJSON = string(convertedJSON)
+		return nil
+	}
+
+	// If not an array, verify it's a valid map format
+	var mapArgs map[string][]string
+	if err := json.Unmarshal([]byte(*argsJSON), &mapArgs); err != nil {
+		return fmt.Errorf("invalid format of arguments, must be valid JSON array or map: %v", err)
+	}
+
+	return nil
+}
+
 // getCLIArgsMap returns args that support both array and map formats
-// Array format is converted to map with "default" key for backward compatibility
+// Array format is automatically converted to map with "default" key for backward compatibility
 // Returns: templateArgsMap (map), taskArgsMap (map), err
 func (t *LocalJob) getCLIArgsMap() (templateArgsMap map[string][]string, taskArgsMap map[string][]string, err error) {
 
+	// Convert template arguments if needed
+	if err = convertArgsJSONIfArray(t.Template.Arguments); err != nil {
+		return
+	}
+
+	// Convert task arguments if needed
+	if t.Template.AllowOverrideArgsInTask {
+		if err = convertArgsJSONIfArray(t.Task.Arguments); err != nil {
+			return
+		}
+	}
+
+	// Now parse as map format (both should be maps after conversion)
 	if t.Template.Arguments != nil {
-		// Try to unmarshal as array first
-		var templateArgs []string
-		err = json.Unmarshal([]byte(*t.Template.Arguments), &templateArgs)
+		err = json.Unmarshal([]byte(*t.Template.Arguments), &templateArgsMap)
 		if err != nil {
-			// If array fails, try map format
-			err = json.Unmarshal([]byte(*t.Template.Arguments), &templateArgsMap)
-			if err != nil {
-				err = fmt.Errorf("invalid format of the template extra arguments, must be valid JSON array or map")
-				return
-			}
-			err = nil // Clear error since map parsing succeeded
-		} else {
-			// Array format: convert to map with "default" key
-			templateArgsMap = map[string][]string{
-				"default": templateArgs,
-			}
+			err = fmt.Errorf("failed to parse template arguments as map: %v", err)
+			return
 		}
 	}
 
 	if t.Template.AllowOverrideArgsInTask && t.Task.Arguments != nil {
-		// Try to unmarshal as array first
-		var taskArgs []string
-		err = json.Unmarshal([]byte(*t.Task.Arguments), &taskArgs)
+		err = json.Unmarshal([]byte(*t.Task.Arguments), &taskArgsMap)
 		if err != nil {
-			// If array fails, try map format
-			err = json.Unmarshal([]byte(*t.Task.Arguments), &taskArgsMap)
-			if err != nil {
-				err = fmt.Errorf("invalid format of the task extra arguments, must be valid JSON array or map")
-				return
-			}
-			err = nil // Clear error since map parsing succeeded
-		} else {
-			// Array format: convert to map with "default" key
-			taskArgsMap = map[string][]string{
-				"default": taskArgs,
-			}
+			err = fmt.Errorf("failed to parse task arguments as map: %v", err)
+			return
 		}
 	}
 

--- a/services/tasks/LocalJob.go
+++ b/services/tasks/LocalJob.go
@@ -686,12 +686,21 @@ func (t *LocalJob) Run(username string, incomingVersion *string, alias string) (
 		}
 		// Use Terraform-specific prepareRun with init args
 		if tfApp, ok := t.App.(*db_lib.TerraformApp); ok {
+			initArgs := []string(nil)
+			if argsMap != nil {
+				if stageArgs, ok := argsMap["init"]; ok {
+					initArgs = stageArgs
+				} else if defaultArgs, ok := argsMap["default"]; ok {
+					initArgs = defaultArgs
+				}
+			}
+
 			err = t.prepareRunTerraform(tfApp, db_lib.LocalAppInstallingArgs{
 				EnvironmentVars: environmentVariables,
 				TplParams:       tplParams,
 				Params:          params,
 				Installer:       t.KeyInstaller,
-			}, argsMap["init"])
+			}, initArgs)
 			if err != nil {
 				return err
 			}

--- a/services/tasks/LocalJob.go
+++ b/services/tasks/LocalJob.go
@@ -675,8 +675,6 @@ func (t *LocalJob) Run(username string, incomingVersion *string, alias string) (
 			if argsMap != nil {
 				if stageArgs, ok := argsMap["init"]; ok {
 					initArgs = stageArgs
-				} else if defaultArgs, ok := argsMap["default"]; ok {
-					initArgs = defaultArgs
 				}
 			}
 


### PR DESCRIPTION
- **feat(be): add staged cli args**
- **refactor(be): remove extra field**
- **fix(be): convert array arguments to map {default: [...]}**

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduce map-based CLI args with stage-specific support (init/plan/apply) for Terraform, keeping array format via "default" fallback and updating orchestration accordingly.
> 
> - **Backend API / Args Model**
>   - `LocalAppRunningArgs.CliArgs` switched to `map[string][]string` with `"default"` fallback for backward compatibility.
>   - New parsing helpers in `services/tasks/LocalJob.go`: `convertArgsJSONIfArray()` and `getCLIArgsMap()` to accept array or map JSON and normalize to map.
> - **Terraform execution**
>   - `getTerraformArgs()` now returns a stage-arg map; merges template/task args per stage and appends common flags/vars/secrets to all non-`init` stages.
>   - `TerraformApp.init()` accepts extra init args; new `InstallRequirementsWithInitArgs()` wires init-stage args.
>   - `TerraformApp.Run()` selects stage-specific args for `plan`/`apply` with `"default"` fallback.
> - **Task orchestration**
>   - `LocalJob.Run()` retrieves Terraform args prior to prepare, passing `init` args via `prepareRunTerraform()`; non-Terraform apps convert args to `{"default": [...]}`.
> - **Other apps**
>   - `AnsibleApp.Run()` and `ShellApp.Run()` now consume `CliArgs["default"]`.
> - **Docs & examples**
>   - Added `TERRAFORM_ARGS_IMPROVEMENT.md` and `examples/terraform_args_example.json` demonstrating legacy and stage-specific formats.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e8a49739c335316fa07bb28228afbfc6915e0123. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->