### PR TITLE
Disabling secret extra vars and converting survey secret vars to env vars

### DIFF
--- a/services/tasks/LocalJob.go
+++ b/services/tasks/LocalJob.go
@@ -3,7 +3,6 @@ package tasks
 import (
 	"encoding/json"
 	"fmt"
-	"maps"
 	"os"
 	"strings"
 
@@ -118,7 +117,6 @@ func (t *LocalJob) getEnvironmentExtraVars(username string, incomingVersion *str
 
 func (t *LocalJob) getEnvironmentExtraVarsJSON(username string, incomingVersion *string) (str string, err error) {
 	extraVars := make(map[string]any)
-	extraSecretVars := make(map[string]any)
 
 	if t.Environment.JSON != "" {
 		err = json.Unmarshal([]byte(t.Environment.JSON), &extraVars)
@@ -126,15 +124,6 @@ func (t *LocalJob) getEnvironmentExtraVarsJSON(username string, incomingVersion 
 			return
 		}
 	}
-	if t.Secret != "" {
-		err = json.Unmarshal([]byte(t.Secret), &extraSecretVars)
-		if err != nil {
-			return
-		}
-	}
-	t.Secret = "{}"
-
-	maps.Copy(extraVars, extraSecretVars)
 
 	taskDetails := make(map[string]any)
 
@@ -186,6 +175,15 @@ func (t *LocalJob) getEnvironmentENV() (res []string, err error) {
 			return
 		}
 	}
+
+	if t.Secret != "" {
+		err = json.Unmarshal([]byte(t.Secret), &environmentVars)
+		if err != nil {
+			return
+		}
+	}
+
+	t.Secret = "{}"
 
 	for key, val := range environmentVars {
 		res = append(res, fmt.Sprintf("%s=%s", key, val))
@@ -449,12 +447,12 @@ func (t *LocalJob) getPlaybookArgs(username string, incomingVersion *string) (ar
 		args = append(args, "--extra-vars", extraVars)
 	}
 
-	for _, secret := range t.Environment.Secrets {
-		if secret.Type != db.EnvironmentSecretVar {
-			continue
-		}
-		args = append(args, "--extra-vars", fmt.Sprintf("%s=%s", secret.Name, secret.Secret))
-	}
+	//for _, secret := range t.Environment.Secrets {
+	//	if secret.Type != db.EnvironmentSecretVar {
+	//		continue
+	//	}
+	//	args = append(args, "--extra-vars", fmt.Sprintf("%s=%s", secret.Name, secret.Secret))
+	//}
 
 	templateArgs, taskArgs, err := t.getCLIArgs()
 	if err != nil {

--- a/web/src/components/EnvironmentForm.vue
+++ b/web/src/components/EnvironmentForm.vue
@@ -239,6 +239,7 @@
           <pre>{{ item.secret_storage_key_prefix }}*</pre>
         </div>
 
+<!--
         <div>
           <v-subheader class="px-0">
             {{ $t('extraVariables') }}
@@ -311,7 +312,7 @@
             </template>
           </v-data-table>
         </div>
-
+-->
         <div>
           <v-subheader class="px-0 mt-4">
             {{ $t('environmentVariables') }}


### PR DESCRIPTION
When running an ansible playbook with debug level 6, secret variables are visible in the report. 
This pull request fixes this by disabling secret extra vars and replaces secret survey vars with env vars.

<img width="894" height="300" alt="изображение" src="https://github.com/user-attachments/assets/53638b27-e631-4ec0-82d8-95ab6e875d1e" />

