### PR TITLE
Multi-repository task support

### DIFF
--- a/db/Store.go
+++ b/db/Store.go
@@ -282,6 +282,9 @@ type TemplateManager interface {
 	CreateTemplateVault(vault TemplateVault) (TemplateVault, error)
 	UpdateTemplateVaults(projectID int, templateID int, vaults []TemplateVault) error
 
+	GetTemplateAdditionalRepositories(projectID int, templateID int) ([]TemplateAdditionalRepository, error)
+	UpdateTemplateAdditionalRepositories(projectID int, templateID int, repos []TemplateAdditionalRepository) error
+
 	GetTemplatePermission(projectID int, templateID int, userID int) (ProjectUserPermission, error)
 	GetTemplateRoles(projectID int, templateID int) ([]TemplateRolePerm, error)
 	CreateTemplateRole(role TemplateRolePerm) (TemplateRolePerm, error)
@@ -587,6 +590,15 @@ var TemplateProps = ObjectProps{
 	ReferringColumnSuffix: "template_id",
 	SortableColumns:       []string{"name", "playbook", "inventory", "environment", "repository"},
 	DefaultSortingColumn:  "name",
+}
+
+var TemplateAdditionalRepositoryProps = ObjectProps{
+	TableName:             "project__template_additional_repository",
+	Type:                  reflect.TypeOf(TemplateAdditionalRepository{}),
+	PrimaryColumnName:     "id",
+	ReferringColumnSuffix: "template_id",
+	SortableColumns:       []string{"position", "path"},
+	DefaultSortingColumn:  "position",
 }
 
 var ProjectUserProps = ObjectProps{

--- a/db/Template.go
+++ b/db/Template.go
@@ -130,6 +130,8 @@ type Template struct {
 
 	Vaults []TemplateVault `db:"-" json:"vaults,omitempty" backup:"-"`
 
+	AdditionalRepositories []TemplateAdditionalRepository `db:"-" json:"additional_repositories,omitempty" backup:"-"`
+
 	Type            TemplateType `db:"type" json:"type,omitempty"`
 	StartVersion    *string      `db:"start_version" json:"start_version,omitempty"`
 	BuildTemplateID *int         `db:"build_template_id" json:"build_template_id,omitempty" backup:"-"`
@@ -226,6 +228,13 @@ func FillTemplate(d Store, template *Template) (err error) {
 		return
 	}
 	template.Vaults = vaults
+
+	var additionalRepos []TemplateAdditionalRepository
+	additionalRepos, err = d.GetTemplateAdditionalRepositories(template.ProjectID, template.ID)
+	if err != nil {
+		return
+	}
+	template.AdditionalRepositories = additionalRepos
 
 	var tasks []TaskWithTpl
 	tasks, err = d.GetTemplateTasks(template.ProjectID, template.ID, RetrieveQueryParams{Count: 1})

--- a/db/TemplateAdditionalRepository.go
+++ b/db/TemplateAdditionalRepository.go
@@ -29,11 +29,11 @@ func (tar *TemplateAdditionalRepository) Validate() error {
 		return &ValidationError{"additional repository path cannot be empty"}
 	}
 
-	// Validate repository type - only git repos allowed
+	// Validate repository type - only git/ssh/https repos allowed
 	if tar.Repository != nil {
 		repoType := tar.Repository.GetType()
-		if repoType != RepositoryGit && repoType != RepositorySSH {
-			return &ValidationError{"additional repositories must be git type"}
+		if repoType != RepositoryGit && repoType != RepositorySSH && repoType != RepositoryHTTP {
+			return &ValidationError{"additional repositories must be git, ssh, or https type"}
 		}
 	}
 

--- a/db/TemplateAdditionalRepository.go
+++ b/db/TemplateAdditionalRepository.go
@@ -1,0 +1,75 @@
+package db
+
+import (
+	"path"
+	"regexp"
+	"strconv"
+	"strings"
+
+	"github.com/semaphoreui/semaphore/util"
+)
+
+// TemplateAdditionalRepository represents an additional repository attached to a template
+type TemplateAdditionalRepository struct {
+	ID           int        `db:"id" json:"id" backup:"-"`
+	TemplateID   int        `db:"template_id" json:"template_id" backup:"-"`
+	RepositoryID int        `db:"repository_id" json:"repository_id" binding:"required"`
+	Path         string     `db:"path" json:"path" binding:"required"`
+	GitBranch    *string    `db:"git_branch" json:"git_branch,omitempty"`
+	Position     int        `db:"position" json:"position"`
+	Repository   *Repository `db:"-" json:"repository,omitempty" backup:"-"`
+}
+
+// Validate validates the TemplateAdditionalRepository
+func (tar *TemplateAdditionalRepository) Validate() error {
+	// Remove leading and trailing slashes
+	tar.Path = strings.Trim(tar.Path, "/")
+
+	if tar.Path == "" {
+		return &ValidationError{"additional repository path cannot be empty"}
+	}
+
+	// Validate repository type - only git repos allowed
+	if tar.Repository != nil {
+		repoType := tar.Repository.GetType()
+		if repoType != RepositoryGit && repoType != RepositorySSH {
+			return &ValidationError{"additional repositories must be git type"}
+		}
+	}
+
+	// Path validation: alphanumeric, dash, underscore only
+	// Prevents directory traversal attacks
+	pathRegex := regexp.MustCompile(`^[a-zA-Z0-9_/-]+$`)
+	if !pathRegex.MatchString(tar.Path) {
+		return &ValidationError{"path must contain only alphanumeric characters, dashes, underscores, and forward slashes"}
+	}
+
+	if len(tar.Path) > 255 {
+		return &ValidationError{"path cannot exceed 255 characters"}
+	}
+
+	// Check for directory traversal attempts
+	if strings.Contains(tar.Path, "..") || strings.Contains(tar.Path, "\\") {
+		return &ValidationError{"path cannot contain '..' or '\\'"}
+	}
+
+	// Reserved paths
+	reservedPaths := []string{".", "..", "tmp", "cache", "logs", "log"}
+	for _, reserved := range reservedPaths {
+		if strings.EqualFold(tar.Path, reserved) {
+			return &ValidationError{"path '" + reserved + "' is reserved"}
+		}
+	}
+
+	return nil
+}
+
+// GetFullPath returns the full filesystem path for this additional repository
+func (tar *TemplateAdditionalRepository) GetFullPath(projectID int, templateID int) string {
+	if tar.Repository == nil {
+		return ""
+	}
+	basePath := util.Config.GetProjectTmpDir(projectID)
+	repoDir := "repository_" + strconv.Itoa(tar.RepositoryID) + "_template_" + strconv.Itoa(templateID)
+	return path.Join(basePath, repoDir, "repos", tar.Path)
+}

--- a/db/TemplateAdditionalRepository_test.go
+++ b/db/TemplateAdditionalRepository_test.go
@@ -1,0 +1,200 @@
+package db
+
+import (
+	"testing"
+)
+
+func TestTemplateAdditionalRepository_Validate_ValidPath(t *testing.T) {
+	tar := &TemplateAdditionalRepository{
+		Path: "libs/mylib",
+	}
+
+	err := tar.Validate()
+	if err != nil {
+		t.Fatalf("expected no error for valid path, got: %v", err)
+	}
+}
+
+func TestTemplateAdditionalRepository_Validate_EmptyPath(t *testing.T) {
+	tar := &TemplateAdditionalRepository{
+		Path: "",
+	}
+
+	err := tar.Validate()
+	if err == nil {
+		t.Fatal("expected error for empty path")
+	}
+}
+
+func TestTemplateAdditionalRepository_Validate_PathWithLeadingSlash(t *testing.T) {
+	tar := &TemplateAdditionalRepository{
+		Path: "/libs/mylib",
+	}
+
+	err := tar.Validate()
+	if err != nil {
+		t.Fatalf("expected no error, leading slash should be trimmed, got: %v", err)
+	}
+
+	if tar.Path != "libs/mylib" {
+		t.Fatalf("expected path 'libs/mylib' after trim, got '%s'", tar.Path)
+	}
+}
+
+func TestTemplateAdditionalRepository_Validate_PathWithTrailingSlash(t *testing.T) {
+	tar := &TemplateAdditionalRepository{
+		Path: "libs/mylib/",
+	}
+
+	err := tar.Validate()
+	if err != nil {
+		t.Fatalf("expected no error, trailing slash should be trimmed, got: %v", err)
+	}
+
+	if tar.Path != "libs/mylib" {
+		t.Fatalf("expected path 'libs/mylib' after trim, got '%s'", tar.Path)
+	}
+}
+
+func TestTemplateAdditionalRepository_Validate_PathWithInvalidCharacters(t *testing.T) {
+	invalidPaths := []string{
+		"libs/my lib",     // space
+		"libs/my@lib",     // @
+		"libs/my$lib",     // $
+		"libs/my&lib",     // &
+		"libs/my*lib",     // *
+		"libs/my(lib)",    // parentheses
+		"libs/my[lib]",    // brackets
+		"libs/my{lib}",    // braces
+		"libs/my;lib",     // semicolon
+		"libs/my:lib",     // colon
+		"libs/my'lib",     // quote
+		"libs/my\"lib",    // double quote
+		"libs/my<lib>",    // angle brackets
+		"libs/my|lib",     // pipe
+	}
+
+	for _, invalidPath := range invalidPaths {
+		tar := &TemplateAdditionalRepository{
+			Path: invalidPath,
+		}
+
+		err := tar.Validate()
+		if err == nil {
+			t.Fatalf("expected error for invalid path '%s'", invalidPath)
+		}
+	}
+}
+
+func TestTemplateAdditionalRepository_Validate_PathWithDirectoryTraversal(t *testing.T) {
+	tar := &TemplateAdditionalRepository{
+		Path: "libs/../../../etc/passwd",
+	}
+
+	err := tar.Validate()
+	if err == nil {
+		t.Fatal("expected error for path with directory traversal")
+	}
+}
+
+func TestTemplateAdditionalRepository_Validate_PathWithBackslash(t *testing.T) {
+	tar := &TemplateAdditionalRepository{
+		Path: "libs\\mylib",
+	}
+
+	err := tar.Validate()
+	if err == nil {
+		t.Fatal("expected error for path with backslash")
+	}
+}
+
+func TestTemplateAdditionalRepository_Validate_PathTooLong(t *testing.T) {
+	longPath := ""
+	for i := 0; i < 260; i++ {
+		longPath += "a"
+	}
+
+	tar := &TemplateAdditionalRepository{
+		Path: longPath,
+	}
+
+	err := tar.Validate()
+	if err == nil {
+		t.Fatal("expected error for path exceeding 255 characters")
+	}
+}
+
+func TestTemplateAdditionalRepository_Validate_ReservedPaths(t *testing.T) {
+	reservedPaths := []string{".", "..", "tmp", "cache", "logs", "log"}
+
+	for _, reserved := range reservedPaths {
+		tar := &TemplateAdditionalRepository{
+			Path: reserved,
+		}
+
+		err := tar.Validate()
+		if err == nil {
+			t.Fatalf("expected error for reserved path '%s'", reserved)
+		}
+	}
+}
+
+func TestTemplateAdditionalRepository_Validate_InvalidRepositoryType(t *testing.T) {
+	tar := &TemplateAdditionalRepository{
+		Path: "libs/mylib",
+		Repository: &Repository{
+			GitURL: "file:///path/to/repo",
+		},
+	}
+
+	err := tar.Validate()
+	if err == nil {
+		t.Fatal("expected error for non-git repository type")
+	}
+}
+
+func TestTemplateAdditionalRepository_Validate_ValidRepositoryTypes(t *testing.T) {
+	validURLs := map[string]string{
+		"git":   "git://github.com/test/repo",
+		"ssh":   "git@github.com:test/repo.git",
+		"https": "https://github.com/test/repo",
+	}
+
+	for repoType, gitURL := range validURLs {
+		tar := &TemplateAdditionalRepository{
+			Path: "libs/mylib",
+			Repository: &Repository{
+				GitURL: gitURL,
+			},
+		}
+
+		err := tar.Validate()
+		if err != nil {
+			t.Fatalf("expected no error for repository type '%s' with URL '%s', got: %v", repoType, gitURL, err)
+		}
+	}
+}
+
+func TestTemplateAdditionalRepository_Validate_ValidPathVariations(t *testing.T) {
+	validPaths := []string{
+		"libs/mylib",
+		"libs/my-lib",
+		"libs/my_lib",
+		"libs/my-lib_v2",
+		"a/b/c/d/e",
+		"mylib",
+		"libs/my-lib-123",
+		"libs/MY-LIB",
+	}
+
+	for _, validPath := range validPaths {
+		tar := &TemplateAdditionalRepository{
+			Path: validPath,
+		}
+
+		err := tar.Validate()
+		if err != nil {
+			t.Fatalf("expected no error for valid path '%s', got: %v", validPath, err)
+		}
+	}
+}

--- a/db/bolt/template.go
+++ b/db/bolt/template.go
@@ -26,6 +26,10 @@ func (d *BoltDb) CreateTemplate(template db.Template) (newTemplate db.Template, 
 	if err != nil {
 		return
 	}
+	err = d.UpdateTemplateAdditionalRepositories(template.ProjectID, newTemplate.ID, template.AdditionalRepositories)
+	if err != nil {
+		return
+	}
 	err = db.FillTemplate(d, &newTemplate)
 	return
 }
@@ -42,7 +46,11 @@ func (d *BoltDb) UpdateTemplate(template db.Template) error {
 	if err != nil {
 		return err
 	}
-	return d.UpdateTemplateVaults(template.ProjectID, template.ID, template.Vaults)
+	err = d.UpdateTemplateVaults(template.ProjectID, template.ID, template.Vaults)
+	if err != nil {
+		return err
+	}
+	return d.UpdateTemplateAdditionalRepositories(template.ProjectID, template.ID, template.AdditionalRepositories)
 }
 
 func (d *BoltDb) setTemplateDescriptionTx(projectID int, templateID int, description string, tx *bbolt.Tx) error {

--- a/db/bolt/template_additional_repository.go
+++ b/db/bolt/template_additional_repository.go
@@ -1,0 +1,84 @@
+package bolt
+
+import (
+	"sort"
+
+	"github.com/semaphoreui/semaphore/db"
+	"go.etcd.io/bbolt"
+)
+
+func (d *BoltDb) GetTemplateAdditionalRepositories(projectID int, templateID int) (repos []db.TemplateAdditionalRepository, err error) {
+	err = d.getObjects(0, db.TemplateAdditionalRepositoryProps, db.RetrieveQueryParams{
+		SortBy: "position",
+	}, func(i interface{}) bool {
+		repo := i.(db.TemplateAdditionalRepository)
+		return repo.TemplateID == templateID
+	}, &repos)
+
+	if err != nil {
+		return
+	}
+
+	// Sort by position
+	sort.Slice(repos, func(i, j int) bool {
+		if repos[i].Position == repos[j].Position {
+			return repos[i].ID < repos[j].ID
+		}
+		return repos[i].Position < repos[j].Position
+	})
+
+	// Expand Repository data
+	for i := range repos {
+		var repo db.Repository
+		repo, err = d.GetRepository(projectID, repos[i].RepositoryID)
+		if err != nil {
+			return
+		}
+		repos[i].Repository = &repo
+	}
+
+	return
+}
+
+func (d *BoltDb) UpdateTemplateAdditionalRepositories(projectID int, templateID int, repos []db.TemplateAdditionalRepository) (err error) {
+	var oldRepos []db.TemplateAdditionalRepository
+
+	oldRepos, err = d.GetTemplateAdditionalRepositories(projectID, templateID)
+
+	err = d.db.Update(func(tx *bbolt.Tx) error {
+		// Delete all old additional repositories
+		for _, oldRepo := range oldRepos {
+			err = d.deleteObject(0, db.TemplateAdditionalRepositoryProps, intObjectID(oldRepo.ID), tx)
+			if err != nil {
+				return err
+			}
+		}
+
+		// Create new additional repositories
+		for _, repo := range repos {
+			// Load repository data for validation
+			var repository db.Repository
+			repository, err = d.GetRepository(projectID, repo.RepositoryID)
+			if err != nil {
+				return err
+			}
+			repo.Repository = &repository
+
+			err = repo.Validate()
+			if err != nil {
+				return err
+			}
+
+			repo.TemplateID = templateID
+
+			_, err = d.createObjectTx(tx, 0, db.TemplateAdditionalRepositoryProps, repo)
+			if err != nil {
+				return err
+			}
+		}
+
+		return nil
+	})
+
+	return
+}

--- a/db/bolt/template_additional_repository.go
+++ b/db/bolt/template_additional_repository.go
@@ -8,7 +8,7 @@ import (
 )
 
 func (d *BoltDb) GetTemplateAdditionalRepositories(projectID int, templateID int) (repos []db.TemplateAdditionalRepository, err error) {
-	err = d.getObjects(0, db.TemplateAdditionalRepositoryProps, db.RetrieveQueryParams{
+	err = d.getObjects(projectID, db.TemplateAdditionalRepositoryProps, db.RetrieveQueryParams{
 		SortBy: "position",
 	}, func(i interface{}) bool {
 		repo := i.(db.TemplateAdditionalRepository)
@@ -44,11 +44,14 @@ func (d *BoltDb) UpdateTemplateAdditionalRepositories(projectID int, templateID 
 	var oldRepos []db.TemplateAdditionalRepository
 
 	oldRepos, err = d.GetTemplateAdditionalRepositories(projectID, templateID)
+	if err != nil {
+		return err
+	}
 
 	err = d.db.Update(func(tx *bbolt.Tx) error {
 		// Delete all old additional repositories
 		for _, oldRepo := range oldRepos {
-			err = d.deleteObject(0, db.TemplateAdditionalRepositoryProps, intObjectID(oldRepo.ID), tx)
+			err = d.deleteObject(projectID, db.TemplateAdditionalRepositoryProps, intObjectID(oldRepo.ID), tx)
 			if err != nil {
 				return err
 			}
@@ -71,7 +74,7 @@ func (d *BoltDb) UpdateTemplateAdditionalRepositories(projectID int, templateID 
 
 			repo.TemplateID = templateID
 
-			_, err = d.createObjectTx(tx, 0, db.TemplateAdditionalRepositoryProps, repo)
+			_, err = d.createObjectTx(tx, projectID, db.TemplateAdditionalRepositoryProps, repo)
 			if err != nil {
 				return err
 			}

--- a/db/bolt/template_additional_repository_test.go
+++ b/db/bolt/template_additional_repository_test.go
@@ -1,0 +1,263 @@
+package bolt
+
+import (
+	"github.com/semaphoreui/semaphore/db"
+	"github.com/semaphoreui/semaphore/pkg/tz"
+	"testing"
+)
+
+func TestGetTemplateAdditionalRepositories(t *testing.T) {
+	store := CreateTestStore()
+
+	proj, err := store.CreateProject(db.Project{
+		Created: tz.Now(),
+		Name:    "TestProject",
+	})
+	if err != nil {
+		t.Fatal(err.Error())
+	}
+
+	// Create access key first
+	key, err := store.CreateAccessKey(db.AccessKey{
+		Name:      "TestKey",
+		Type:      "none",
+		ProjectID: &proj.ID,
+	})
+	if err != nil {
+		t.Fatal(err.Error())
+	}
+
+	repo, err := store.CreateRepository(db.Repository{
+		ProjectID: proj.ID,
+		Name:      "TestRepo",
+		GitURL:    "https://github.com/test/repo",
+		GitBranch: "main",
+		SSHKeyID:  key.ID,
+	})
+	if err != nil {
+		t.Fatal(err.Error())
+	}
+
+	template, err := store.CreateTemplate(db.Template{
+		ProjectID: proj.ID,
+		Name:      "TestTemplate",
+		Playbook:  "test.yml",
+	})
+	if err != nil {
+		t.Fatal(err.Error())
+	}
+
+	addRepos := []db.TemplateAdditionalRepository{
+		{
+			TemplateID:   template.ID,
+			RepositoryID: repo.ID,
+			Path:         "libs/mylib",
+			Position:     0,
+		},
+	}
+
+	err = store.UpdateTemplateAdditionalRepositories(proj.ID, template.ID, addRepos)
+	if err != nil {
+		t.Fatalf("UpdateTemplateAdditionalRepositories failed: %v", err)
+	}
+
+	repos, err := store.GetTemplateAdditionalRepositories(proj.ID, template.ID)
+	if err != nil {
+		t.Fatalf("GetTemplateAdditionalRepositories failed: %v", err)
+	}
+
+	if len(repos) != 1 {
+		t.Fatalf("expected 1 additional repository, got %d", len(repos))
+	}
+
+	if repos[0].Path != "libs/mylib" {
+		t.Fatalf("expected path 'libs/mylib', got '%s'", repos[0].Path)
+	}
+}
+
+func TestUpdateTemplateAdditionalRepositories(t *testing.T) {
+	store := CreateTestStore()
+
+	proj, err := store.CreateProject(db.Project{
+		Created: tz.Now(),
+		Name:    "TestProject",
+	})
+	if err != nil {
+		t.Fatal(err.Error())
+	}
+
+	// Create access key first
+	key, err := store.CreateAccessKey(db.AccessKey{
+		Name:      "TestKey",
+		Type:      "none",
+		ProjectID: &proj.ID,
+	})
+	if err != nil {
+		t.Fatal(err.Error())
+	}
+
+	repo1, err := store.CreateRepository(db.Repository{
+		ProjectID: proj.ID,
+		Name:      "TestRepo1",
+		GitURL:    "https://github.com/test/repo1",
+		GitBranch: "main",
+		SSHKeyID:  key.ID,
+	})
+	if err != nil {
+		t.Fatal(err.Error())
+	}
+
+	repo2, err := store.CreateRepository(db.Repository{
+		ProjectID: proj.ID,
+		Name:      "TestRepo2",
+		GitURL:    "https://github.com/test/repo2",
+		GitBranch: "main",
+		SSHKeyID:  key.ID,
+	})
+	if err != nil {
+		t.Fatal(err.Error())
+	}
+
+	template, err := store.CreateTemplate(db.Template{
+		ProjectID: proj.ID,
+		Name:      "TestTemplate",
+		Playbook:  "test.yml",
+	})
+	if err != nil {
+		t.Fatal(err.Error())
+	}
+
+	// Create initial additional repositories
+	addRepos := []db.TemplateAdditionalRepository{
+		{
+			TemplateID:   template.ID,
+			RepositoryID: repo1.ID,
+			Path:         "libs/lib1",
+			Position:     0,
+		},
+	}
+
+	err = store.UpdateTemplateAdditionalRepositories(proj.ID, template.ID, addRepos)
+	if err != nil {
+		t.Fatal(err.Error())
+	}
+
+	// Update with different repositories
+	updatedRepos := []db.TemplateAdditionalRepository{
+		{
+			TemplateID:   template.ID,
+			RepositoryID: repo2.ID,
+			Path:         "libs/lib2",
+			Position:     0,
+		},
+		{
+			TemplateID:   template.ID,
+			RepositoryID: repo1.ID,
+			Path:         "libs/lib1-updated",
+			GitBranch:    strPtr("develop"),
+			Position:     1,
+		},
+	}
+
+	err = store.UpdateTemplateAdditionalRepositories(proj.ID, template.ID, updatedRepos)
+	if err != nil {
+		t.Fatal(err.Error())
+	}
+
+	repos, err := store.GetTemplateAdditionalRepositories(proj.ID, template.ID)
+	if err != nil {
+		t.Fatal(err.Error())
+	}
+
+	if len(repos) != 2 {
+		t.Fatalf("expected 2 additional repositories, got %d", len(repos))
+	}
+
+	if repos[0].Path != "libs/lib2" {
+		t.Fatalf("expected first repo path 'libs/lib2', got '%s'", repos[0].Path)
+	}
+
+	if repos[1].Path != "libs/lib1-updated" {
+		t.Fatalf("expected second repo path 'libs/lib1-updated', got '%s'", repos[1].Path)
+	}
+
+	if repos[1].GitBranch == nil || *repos[1].GitBranch != "develop" {
+		t.Fatalf("expected second repo branch 'develop', got '%v'", repos[1].GitBranch)
+	}
+}
+
+func TestUpdateTemplateAdditionalRepositories_Empty(t *testing.T) {
+	store := CreateTestStore()
+
+	proj, err := store.CreateProject(db.Project{
+		Created: tz.Now(),
+		Name:    "TestProject",
+	})
+	if err != nil {
+		t.Fatal(err.Error())
+	}
+
+	// Create access key first
+	key, err := store.CreateAccessKey(db.AccessKey{
+		Name:      "TestKey",
+		Type:      "none",
+		ProjectID: &proj.ID,
+	})
+	if err != nil {
+		t.Fatal(err.Error())
+	}
+
+	repo, err := store.CreateRepository(db.Repository{
+		ProjectID: proj.ID,
+		Name:      "TestRepo",
+		GitURL:    "https://github.com/test/repo",
+		GitBranch: "main",
+		SSHKeyID:  key.ID,
+	})
+	if err != nil {
+		t.Fatal(err.Error())
+	}
+
+	template, err := store.CreateTemplate(db.Template{
+		ProjectID: proj.ID,
+		Name:      "TestTemplate",
+		Playbook:  "test.yml",
+	})
+	if err != nil {
+		t.Fatal(err.Error())
+	}
+
+	// Create initial additional repository
+	addRepos := []db.TemplateAdditionalRepository{
+		{
+			TemplateID:   template.ID,
+			RepositoryID: repo.ID,
+			Path:         "libs/mylib",
+			Position:     0,
+		},
+	}
+
+	err = store.UpdateTemplateAdditionalRepositories(proj.ID, template.ID, addRepos)
+	if err != nil {
+		t.Fatal(err.Error())
+	}
+
+	// Update with empty list to remove all
+	err = store.UpdateTemplateAdditionalRepositories(proj.ID, template.ID, []db.TemplateAdditionalRepository{})
+	if err != nil {
+		t.Fatal(err.Error())
+	}
+
+	repos, err := store.GetTemplateAdditionalRepositories(proj.ID, template.ID)
+	if err != nil {
+		t.Fatal(err.Error())
+	}
+
+	if len(repos) != 0 {
+		t.Fatalf("expected 0 additional repositories after clearing, got %d", len(repos))
+	}
+}
+
+func strPtr(s string) *string {
+	return &s
+}

--- a/db/sql/migrations/v2.18.0.err.sql
+++ b/db/sql/migrations/v2.18.0.err.sql
@@ -1,0 +1,1 @@
+drop table if exists `project__template_additional_repository`;

--- a/db/sql/migrations/v2.18.0.sql
+++ b/db/sql/migrations/v2.18.0.sql
@@ -1,0 +1,17 @@
+create table `project__template_additional_repository`
+(
+    id            integer primary key autoincrement,
+    template_id   int          not null,
+    repository_id int          not null,
+    path          varchar(255) not null,
+    git_branch    varchar(255),
+    position      int          not null default 0,
+
+    foreign key (`template_id`) references `project__template` (`id`) on delete cascade,
+    foreign key (`repository_id`) references `project__repository` (`id`) on delete cascade,
+
+    unique (`template_id`, `path`)
+);
+
+create index `idx_template_additional_repo_template`
+    on `project__template_additional_repository` (`template_id`);

--- a/db/sql/template.go
+++ b/db/sql/template.go
@@ -68,6 +68,11 @@ func (d *SqlDb) CreateTemplate(template db.Template) (newTemplate db.Template, e
 		return
 	}
 
+	err = d.UpdateTemplateAdditionalRepositories(template.ProjectID, insertID, template.AdditionalRepositories)
+	if err != nil {
+		return
+	}
+
 	err = db.FillTemplate(d, &newTemplate)
 
 	if err != nil {
@@ -140,8 +145,11 @@ func (d *SqlDb) UpdateTemplate(template db.Template) error {
 	}
 
 	err = d.UpdateTemplateVaults(template.ProjectID, template.ID, template.Vaults)
+	if err != nil {
+		return err
+	}
 
-	return err
+	return d.UpdateTemplateAdditionalRepositories(template.ProjectID, template.ID, template.AdditionalRepositories)
 }
 func (d *SqlDb) SetTemplateDescription(projectID int, templateID int, description string) (err error) {
 

--- a/db/sql/template_additional_repository.go
+++ b/db/sql/template_additional_repository.go
@@ -1,0 +1,99 @@
+package sql
+
+import (
+	"strconv"
+	"strings"
+
+	"github.com/Masterminds/squirrel"
+	"github.com/semaphoreui/semaphore/db"
+)
+
+const templateAdditionalRepoColumns = "id, template_id, repository_id, path, git_branch, position"
+
+func (d *SqlDb) GetTemplateAdditionalRepositories(projectID int, templateID int) (repos []db.TemplateAdditionalRepository, err error) {
+	query, args, err := squirrel.Select(templateAdditionalRepoColumns).
+		From("project__template_additional_repository").
+		Where("template_id = ?", templateID).
+		OrderBy("position ASC, id ASC").
+		ToSql()
+
+	if err != nil {
+		return
+	}
+
+	_, err = d.selectAll(&repos, query, args...)
+
+	if err != nil {
+		return
+	}
+
+	// Expand Repository data
+	for i := range repos {
+		var repo db.Repository
+		repo, err = d.GetRepository(projectID, repos[i].RepositoryID)
+		if err != nil {
+			return
+		}
+		repos[i].Repository = &repo
+	}
+
+	return
+}
+
+func (d *SqlDb) UpdateTemplateAdditionalRepositories(projectID int, templateID int, repos []db.TemplateAdditionalRepository) (err error) {
+	if repos == nil {
+		repos = []db.TemplateAdditionalRepository{}
+	}
+
+	var repoIDs []string
+	for _, repo := range repos {
+		// Load repository data for validation
+		var repository db.Repository
+		repository, err = d.GetRepository(projectID, repo.RepositoryID)
+		if err != nil {
+			return
+		}
+		repo.Repository = &repository
+
+		err = repo.Validate()
+		if err != nil {
+			return
+		}
+
+		repo.TemplateID = templateID
+
+		if repo.ID == 0 {
+			// Insert new additional repository
+			var repoID int
+			repoID, err = d.insert("id",
+				"insert into project__template_additional_repository "+
+					"(template_id, repository_id, path, git_branch, position) "+
+					"values (?, ?, ?, ?, ?)",
+				templateID, repo.RepositoryID, repo.Path, repo.GitBranch, repo.Position)
+			if err != nil {
+				return
+			}
+			repoIDs = append(repoIDs, strconv.Itoa(repoID))
+		} else {
+			// Update existing additional repository
+			_, err = d.exec(
+				"update project__template_additional_repository set "+
+					"repository_id=?, path=?, git_branch=?, position=? "+
+					"where id=? and template_id=?",
+				repo.RepositoryID, repo.Path, repo.GitBranch, repo.Position, repo.ID, templateID)
+			repoIDs = append(repoIDs, strconv.Itoa(repo.ID))
+		}
+		if err != nil {
+			return
+		}
+	}
+
+	// Delete removed additional repositories
+	if len(repoIDs) == 0 {
+		_, err = d.exec("delete from project__template_additional_repository where template_id=?", templateID)
+	} else {
+		_, err = d.exec("delete from project__template_additional_repository where template_id=? and id not in ("+strings.Join(repoIDs, ",")+")", templateID)
+	}
+
+	return
+}

--- a/services/tasks/LocalJob.go
+++ b/services/tasks/LocalJob.go
@@ -37,6 +37,7 @@ type LocalJob struct {
 	vaultFileInstallations map[string]ssh.AccessKeyInstallation
 
 	KeyInstaller db_lib.AccessKeyInstaller
+	Store        db.Store // Store provides access to database
 }
 
 func (t *LocalJob) IsKilled() bool {
@@ -804,6 +805,12 @@ func (t *LocalJob) prepareRun(installingArgs db_lib.LocalAppInstallingArgs) erro
 		}
 	}
 
+	// Clone additional repositories
+	if err := t.cloneAdditionalRepositories(); err != nil {
+		t.Log("Failed cloning additional repositories: " + err.Error())
+		return err
+	}
+
 	if err := t.installInventory(); err != nil {
 		t.Log("Failed to install inventory: " + err.Error())
 		return err
@@ -855,6 +862,12 @@ func (t *LocalJob) prepareRunTerraform(tfApp *db_lib.TerraformApp, installingArg
 			t.Log("Failed to checkout repository to required commit: " + err.Error())
 			return err
 		}
+	}
+
+	// Clone additional repositories
+	if err := t.cloneAdditionalRepositories(); err != nil {
+		t.Log("Failed cloning additional repositories: " + err.Error())
+		return err
 	}
 
 	if err := t.installInventory(); err != nil {
@@ -980,4 +993,133 @@ func (t *LocalJob) installVaultKeyFiles() (err error) {
 	}
 
 	return
+}
+
+func (t *LocalJob) cloneAdditionalRepositories() error {
+	additionalRepos, err := t.Store.GetTemplateAdditionalRepositories(t.Template.ProjectID, t.Template.ID)
+	if err != nil {
+		return err
+	}
+
+	reposDir := path.Join(t.getRepoPath(), "repos")
+
+	// Check if user requested to clear additional repos directory
+	shouldClear := false
+	if t.Task.Params != nil {
+		if clearRepos, ok := t.Task.Params["clear_additional_repos"].(bool); ok && clearRepos {
+			shouldClear = true
+		}
+	}
+
+	// If no additional repos configured, always clear repos/ directory if it exists
+	if len(additionalRepos) == 0 {
+		if _, err := os.Stat(reposDir); err == nil {
+			t.Log("No additional repositories configured - removing repos/ directory")
+			if err := os.RemoveAll(reposDir); err != nil {
+				return fmt.Errorf("failed removing repos directory: %w", err)
+			}
+		}
+		return nil
+	}
+
+	// If user requested to clear, remove repos/ directory
+	if shouldClear {
+		if _, err := os.Stat(reposDir); err == nil {
+			t.Log("Clearing additional repositories directory as requested")
+			if err := os.RemoveAll(reposDir); err != nil {
+				return fmt.Errorf("failed clearing repos directory: %w", err)
+			}
+		}
+	}
+
+	t.Log(fmt.Sprintf("Cloning %d additional repositories", len(additionalRepos)))
+
+	for _, addRepo := range additionalRepos {
+		if addRepo.Repository == nil {
+			t.Log(fmt.Sprintf("Warning: Repository %d not loaded, skipping", addRepo.RepositoryID))
+			continue
+		}
+
+		repo := *addRepo.Repository
+
+		// Override git branch from template additional repo if set
+		if addRepo.GitBranch != nil && *addRepo.GitBranch != "" {
+			repo.GitBranch = *addRepo.GitBranch
+		}
+
+		// Override git branch from task params if provided
+		// Task.Params can contain: { "additional_repos": { "path1": { "branch": "feature-x" } } }
+		if t.Task.Params != nil {
+			if addRepoParams, ok := t.Task.Params["additional_repos"].(map[string]interface{}); ok {
+				if pathParams, ok := addRepoParams[addRepo.Path].(map[string]interface{}); ok {
+					if branchOverride, ok := pathParams["branch"].(string); ok && branchOverride != "" {
+						repo.GitBranch = branchOverride
+						t.Log(fmt.Sprintf("Branch override for '%s': %s", addRepo.Path, branchOverride))
+					}
+				}
+			}
+		}
+
+		// Clone to workspace/repos/<path>/
+		// Create repos directory if doesn't exist
+		if err := checkTmpDir(reposDir); err != nil {
+			return fmt.Errorf("failed creating repos directory: %w", err)
+		}
+
+		targetPath := path.Join(reposDir, addRepo.Path)
+
+		t.Log(fmt.Sprintf("Cloning additional repository '%s' to 'repos/%s' (branch: %s)",
+			repo.Name, addRepo.Path, repo.GitBranch))
+
+		gitRepo := db_lib.GitRepository{
+			Logger:     t.Logger,
+			TemplateID: t.Template.ID,
+			Repository: repo,
+			TmpDirName: path.Join(t.Repository.GetDirName(t.Template.ID), "repos", addRepo.Path),
+			Client:     db_lib.CreateDefaultGitClient(t.KeyInstaller),
+		}
+
+		// Check if already cloned
+		err := gitRepo.ValidateRepo()
+		if err != nil {
+			if !os.IsNotExist(err) {
+				// Directory exists but corrupted, remove it
+				err = os.RemoveAll(targetPath)
+				if err != nil {
+					return fmt.Errorf("failed removing corrupted repo '%s': %w", repo.Name, err)
+				}
+			}
+			// Clone fresh
+			if err := gitRepo.Clone(); err != nil {
+				return fmt.Errorf("failed cloning additional repo '%s': %w", repo.Name, err)
+			}
+		} else {
+			// Already exists, try to pull
+			if gitRepo.CanBePulled() {
+				if err := gitRepo.Pull(); err != nil {
+					t.Log(fmt.Sprintf("Pull failed for '%s', re-cloning: %s", repo.Name, err.Error()))
+					// Pull failed, re-clone
+					if err := os.RemoveAll(targetPath); err != nil {
+						return fmt.Errorf("failed removing repo '%s': %w", repo.Name, err)
+					}
+					if err := gitRepo.Clone(); err != nil {
+						return fmt.Errorf("failed re-cloning repo '%s': %w", repo.Name, err)
+					}
+				}
+			}
+		}
+
+		// Checkout to specified branch
+		if err := gitRepo.Checkout(repo.GitBranch); err != nil {
+			return fmt.Errorf("failed checkout '%s' to branch '%s': %w", repo.Name, repo.GitBranch, err)
+		}
+
+		t.Log(fmt.Sprintf("Successfully prepared additional repository '%s' at '%s'", repo.Name, addRepo.Path))
+	}
+
+	return nil
+}
+
+func (t *LocalJob) getRepoPath() string {
+	return t.Repository.GetFullPath(t.Template.ID)
 }

--- a/services/tasks/TaskPool.go
+++ b/services/tasks/TaskPool.go
@@ -399,6 +399,7 @@ func (p *TaskPool) hydrateTaskRunner(taskID int, projectID int) (*TaskRunner, er
 			Logger:       app.SetLogger(tr),
 			App:          app,
 			KeyInstaller: p.keyInstallationService,
+			Store:        p.store,
 		}
 	}
 	tr.job = job
@@ -737,6 +738,7 @@ func (p *TaskPool) AddTask(
 			Logger:       app.SetLogger(taskRunner),
 			App:          app,
 			KeyInstaller: p.keyInstallationService,
+			Store:        p.store,
 		}
 	}
 

--- a/web/src/components/TaskForm.vue
+++ b/web/src/components/TaskForm.vue
@@ -123,6 +123,35 @@
         && template.allow_override_branch_in_task"
     />
 
+    <div v-if="additionalRepos && additionalRepos.length > 0" class="mt-2">
+      <h4 class="mb-3">{{ $t('additionalRepositoryBranches') }}</h4>
+
+      <v-autocomplete
+        v-for="addRepo in additionalRepos"
+        :key="addRepo.id"
+        v-model="additionalRepoBranches[addRepo.path]"
+        :label="`${addRepo.repository.name} (${
+          addRepo.git_branch || addRepo.repository.git_branch
+        })`"
+        :placeholder="addRepo.git_branch || addRepo.repository.git_branch"
+        :items="additionalReposBranchesList[addRepo.repository_id] || []"
+        outlined
+        dense
+        clearable
+        :disabled="formSaving"
+      >
+        <template v-slot:prepend-inner>
+          <v-icon small class="mr-1">mdi-source-branch</v-icon>
+        </template>
+      </v-autocomplete>
+
+      <v-checkbox
+        class="mt-0"
+        :label="$t('clearAdditionalRepositories')"
+        v-model="clearAdditionalRepos"
+      />
+    </div>
+
     <v-autocomplete
       v-model="inventory_id"
       :label="fieldLabel('inventory')"
@@ -205,6 +234,10 @@ export default {
         indentWithTabs: false,
       },
       inventory: null,
+      additionalRepos: null,
+      additionalRepoBranches: {},
+      additionalReposBranchesList: {}, // { repo_id: [branches] }
+      clearAdditionalRepos: false,
     };
   },
 
@@ -289,6 +322,23 @@ export default {
       this.item.arguments = JSON.stringify(args || []);
     },
 
+    async loadAdditionalRepoBranches(repoId) {
+      if (!repoId) {
+        return;
+      }
+
+      try {
+        const branches = await this.loadProjectEndpoint(
+          `/repositories/${repoId}/branches`,
+        );
+        this.$set(this.additionalReposBranchesList, repoId, branches);
+      } catch (error) {
+        // If branches can't be loaded, autocomplete will be empty
+        console.error(`Failed to load branches for repo ${repoId}:`, error);
+        this.$set(this.additionalReposBranchesList, repoId, []);
+      }
+    },
+
     getTaskMessage(task) {
       let buildTask = task;
 
@@ -326,6 +376,32 @@ export default {
     beforeSave() {
       this.item.environment = JSON.stringify(this.editedEnvironment);
       this.item.secret = JSON.stringify(this.editedSecretEnvironment);
+
+      // Save additional repository branch overrides to params
+      if (this.additionalRepoBranches && Object.keys(this.additionalRepoBranches).length > 0) {
+        if (!this.item.params) {
+          this.item.params = {};
+        }
+
+        const additionalRepoParams = {};
+        Object.entries(this.additionalRepoBranches).forEach(([path, branch]) => {
+          if (branch && branch.trim() !== '') {
+            additionalRepoParams[path] = { branch };
+          }
+        });
+
+        if (Object.keys(additionalRepoParams).length > 0) {
+          this.item.params.additional_repos = additionalRepoParams;
+        }
+      }
+
+      // Save clear additional repos option
+      if (this.clearAdditionalRepos) {
+        if (!this.item.params) {
+          this.item.params = {};
+        }
+        this.item.params.clear_additional_repos = true;
+      }
     },
 
     refreshItem() {
@@ -350,6 +426,7 @@ export default {
       [
         this.buildTasks,
         this.inventory,
+        this.additionalRepos,
       ] = await Promise.all([
 
         this.template.type === 'deploy' ? (await axios({
@@ -363,7 +440,22 @@ export default {
           url: this.getInventoryUrl(),
           responseType: 'json',
         })).data : [],
+
+        this.template?.id ? (await axios({
+          keys: 'get',
+          url: `/api/project/${this.projectId}/templates/${this.template.id}`,
+          responseType: 'json',
+        })).data.additional_repositories || [] : [],
       ]);
+
+      // Load branches for additional repositories
+      if (this.additionalRepos && this.additionalRepos.length > 0) {
+        await Promise.all(
+          this.additionalRepos
+            .filter((addRepo) => addRepo.repository_id)
+            .map((addRepo) => this.loadAdditionalRepoBranches(addRepo.repository_id)),
+        );
+      }
 
       if (this.item.build_task_id == null
         && this.buildTasks.length > 0

--- a/web/src/components/TemplateAdditionalRepositories.vue
+++ b/web/src/components/TemplateAdditionalRepositories.vue
@@ -1,0 +1,231 @@
+<template>
+  <div v-if="showField" class="mb-4">
+    <div class="d-flex align-center mb-3">
+      <h3>
+        {{ $t('additionalRepositories') }}
+        <v-chip class="ml-2" small color="error">New</v-chip>
+      </h3>
+      <v-btn
+        small
+        color="primary"
+        class="ml-3"
+        @click="addRepo"
+        :disabled="formSaving"
+      >
+        <v-icon small left>mdi-plus</v-icon>
+        {{ $t('add') }}
+      </v-btn>
+    </div>
+
+    <v-row>
+      <v-col
+        v-for="(addRepo, index) in repositories"
+        :key="index"
+        cols="12"
+        md="6"
+      >
+        <fieldset
+          class="mb-3"
+          style="padding: 10px;
+                 border-width: 1px;
+                 border-color: rgba(133, 133, 133, 0.4);
+                 background-color: rgba(133, 133, 133, 0.1);
+                 border-radius: 8px;
+                 font-size: 12px;"
+        >
+          <legend
+            style="
+              padding: 0 3px;
+              width: 100%;
+              display: flex;
+              justify-content: space-between;
+              align-items: center;
+            "
+          >
+            <span>{{ $t('repository') }} #{{ index + 1 }}</span>
+            <v-btn
+              icon
+              small
+              color="error"
+              @click="removeRepo(index)"
+              :disabled="formSaving"
+            >
+              <v-icon>mdi-close</v-icon>
+            </v-btn>
+          </legend>
+
+          <v-autocomplete
+            v-model="addRepo.repository_id"
+            :label="$t('repository') + ' *'"
+            :items="gitRepositories"
+            item-value="id"
+            item-text="name"
+            :rules="[v => !!v || $t('repository_required')]"
+            outlined
+            dense
+            hide-details
+            :disabled="formSaving"
+            class="mb-4"
+            @change="onRepositoryChange(index)"
+          ></v-autocomplete>
+
+          <v-text-field
+            v-model="addRepo.path"
+            :label="$t('path') + ' *'"
+            :rules="[
+              v => !!v || $t('path_required'),
+              v => /^[a-zA-Z0-9_/-]+$/.test(v) || $t('pathInvalidCharacters'),
+              v => !isDuplicatePath(v, index) || $t('pathAlreadyUsed'),
+            ]"
+            outlined
+            dense
+            hide-details
+            :disabled="formSaving"
+            :placeholder="$t('exampleMyRepo')"
+            @input="slugifyPath(index)"
+            prefix="repos/"
+          ></v-text-field>
+
+          <div class="mb-3 text-right">
+            <a
+              v-if="!addRepo.git_branch && !addRepo.showBranch"
+              @click="setShowBranch(index, true)"
+            >{{ $t('setBranch') }}</a>
+          </div>
+
+          <div v-if="addRepo.git_branch || addRepo.showBranch">
+            <v-autocomplete
+              v-if="branches[index] && branches[index].length > 0"
+              clearable
+              v-model="addRepo.git_branch"
+              :label="$t('branch')"
+              :items="branches[index]"
+              outlined
+              dense
+              :disabled="formSaving"
+              :placeholder="$t('optional')"
+            ></v-autocomplete>
+
+            <v-text-field
+              v-else
+              clearable
+              v-model="addRepo.git_branch"
+              :label="$t('branch')"
+              outlined
+              dense
+              :disabled="formSaving"
+              :placeholder="$t('optional')"
+            ></v-text-field>
+
+            <div class="text-right" style="margin-top: -12px; margin-bottom: 12px;">
+              <a
+                v-if="addRepo.showBranch"
+                @click="
+                  setShowBranch(index, false);
+                  addRepo.git_branch = null;
+                "
+              >{{ $t('useDefaultBranch') }}</a>
+            </div>
+          </div>
+        </fieldset>
+      </v-col>
+    </v-row>
+  </div>
+</template>
+
+<script>
+export default {
+  props: {
+    value: {
+      type: Array,
+      default: () => [],
+    },
+    gitRepositories: {
+      type: Array,
+      default: () => [],
+    },
+    branches: {
+      type: Object,
+      default: () => ({}),
+    },
+    formSaving: {
+      type: Boolean,
+      default: false,
+    },
+    showField: {
+      type: Boolean,
+      default: true,
+    },
+  },
+
+  computed: {
+    repositories: {
+      get() {
+        return this.value || [];
+      },
+      set(val) {
+        this.$emit('input', val);
+      },
+    },
+  },
+
+  methods: {
+    addRepo() {
+      const repos = [...this.repositories];
+      repos.push({
+        id: 0,
+        repository_id: null,
+        path: '',
+        git_branch: null,
+        position: repos.length,
+        showBranch: false,
+      });
+      this.repositories = repos;
+    },
+
+    removeRepo(index) {
+      const repos = [...this.repositories];
+      repos.splice(index, 1);
+      // Update positions
+      for (let i = 0; i < repos.length; i += 1) {
+        repos[i].position = i;
+      }
+      this.repositories = repos;
+    },
+
+    setShowBranch(index, value) {
+      const repos = [...this.repositories];
+      repos[index].showBranch = value;
+      this.repositories = repos;
+    },
+
+    slugifyPath(index) {
+      const repos = [...this.repositories];
+      const repo = repos[index];
+      if (repo.path) {
+        let slugified = repo.path
+          .replace(/^\/+|\/+$/g, '') // Remove leading and trailing slashes FIRST
+          .toLowerCase()
+          .replace(/[^a-z0-9_/-]/g, '-')
+          .replace(/-+/g, '-')
+          .replace(/^-|-$/g, '');
+        // Remove slashes again at the end to catch any edge cases
+        slugified = slugified.replace(/^\/+|\/+$/g, '');
+        repos[index].path = slugified;
+        this.repositories = repos;
+      }
+    },
+
+    onRepositoryChange(index) {
+      this.$emit('load-branches', index);
+    },
+
+    isDuplicatePath(path, currentIndex) {
+      if (!path) return false;
+      return this.repositories.some((repo, idx) => (
+        idx !== currentIndex && repo.path === path
+      ));
+    },
+  },
+};
+</script>

--- a/web/src/components/TemplateForm.vue
+++ b/web/src/components/TemplateForm.vue
@@ -210,7 +210,7 @@
           <a
             v-if="!item.git_branch && !setBranch"
             @click="setBranch = true"
-          >Set branch</a>
+          >{{ $t('setBranch') }}</a>
 
         </div>
 
@@ -269,7 +269,7 @@
         ></v-autocomplete>
       </v-col>
 
-      <v-col>
+      <v-col class="mb-0">
         <h2 class="mb-4">{{ $t('template_advanced') }}</h2>
 
         <div class="mb-4">
@@ -499,6 +499,16 @@
       </v-col>
 
     </v-row>
+
+    <TemplateAdditionalRepositories
+      v-model="item.additional_repositories"
+      :git-repositories="gitRepositories"
+      :branches="additionalRepoBranches"
+      :form-saving="formSaving"
+      :show-field="needField('repository')"
+      @load-branches="loadAdditionalRepoBranches"
+    />
+
   </v-form>
 </template>
 <style lang="scss">
@@ -518,6 +528,7 @@ import 'codemirror/addon/lint/json-lint.js';
 import 'codemirror/addon/display/placeholder.js';
 import ArgsPicker from '@/components/ArgsPicker.vue';
 import TemplateVaults from '@/components/TemplateVaults.vue';
+import TemplateAdditionalRepositories from '@/components/TemplateAdditionalRepositories.vue';
 import { TEMPLATE_TYPE_ICONS, TEMPLATE_TYPE_TITLES } from '@/lib/constants';
 import AppFieldsMixin from '@/components/AppFieldsMixin';
 import AppsMixin from '@/components/AppsMixin';
@@ -532,6 +543,7 @@ export default {
     TemplateVaults,
     ArgsPicker,
     SurveyVars,
+    TemplateAdditionalRepositories,
   },
 
   props: {
@@ -572,6 +584,7 @@ export default {
       },
       item: {
         task_params: {},
+        additional_repositories: [],
       },
       inventory: null,
       repositories: null,
@@ -590,6 +603,7 @@ export default {
       runnerTags: null,
       branches: null,
       setBranch: false,
+      additionalRepoBranches: {}, // { index: [branches] }
     };
   },
 
@@ -701,6 +715,17 @@ export default {
       return this.item.vaults;
     },
 
+    gitRepositories() {
+      // Filter repositories to only git/ssh/https types for additional repositories
+      if (!this.repositories) {
+        return [];
+      }
+      return this.repositories.filter((repo) => {
+        const type = repo.type || 'ssh';
+        return type === 'git' || type === 'ssh' || type === 'https';
+      });
+    },
+
     isLoaded() {
       // if (this.isNew && this.sourceItemId == null) {
       //   return true;
@@ -723,9 +748,33 @@ export default {
         return;
       }
 
-      this.branches = await this.loadProjectEndpoint(
-        `/repositories/${this.repositoryId}/branches`,
-      );
+      try {
+        this.branches = await this.loadProjectEndpoint(
+          `/repositories/${this.repositoryId}/branches`,
+        );
+      } catch (error) {
+        // If branches can't be loaded (e.g., temp directory doesn't exist),
+        // fallback to text field
+        this.branches = null;
+      }
+    },
+
+    async loadAdditionalRepoBranches(index) {
+      const addRepo = this.item.additional_repositories[index];
+      if (!addRepo || !addRepo.repository_id) {
+        this.$set(this.additionalRepoBranches, index, null);
+        return;
+      }
+
+      try {
+        const branches = await this.loadProjectEndpoint(
+          `/repositories/${addRepo.repository_id}/branches`,
+        );
+        this.$set(this.additionalRepoBranches, index, branches);
+      } catch (error) {
+        // If branches can't be loaded, fallback to text field
+        this.$set(this.additionalRepoBranches, index, null);
+      }
     },
 
     validateBackendFilename(v) {
@@ -843,6 +892,15 @@ export default {
           }
         }
 
+        if (item.additional_repositories) {
+          for (let i = 0; i < item.additional_repositories.length; i += 1) {
+            item.additional_repositories[i].id = 0;
+            item.additional_repositories[i].showBranch = (
+              !!item.additional_repositories[i].git_branch
+            );
+          }
+        }
+
         const sourceSchedule = (await this.loadProjectEndpoint(`/templates/${this.sourceItemId}/schedules`))[0];
 
         if (sourceSchedule != null) {
@@ -872,6 +930,21 @@ export default {
       }
 
       this.itemTypeIndex = Object.keys(TEMPLATE_TYPE_ICONS).indexOf(this.item.type);
+
+      // Initialize showBranch for additional repositories
+      if (this.item.additional_repositories) {
+        for (let i = 0; i < this.item.additional_repositories.length; i += 1) {
+          this.$set(
+            this.item.additional_repositories[i],
+            'showBranch',
+            !!this.item.additional_repositories[i].git_branch,
+          );
+          // Load branches for additional repositories
+          if (this.item.additional_repositories[i].repository_id) {
+            this.loadAdditionalRepoBranches(i);
+          }
+        }
+      }
     },
 
     getItemsUrl() {
@@ -943,6 +1016,7 @@ export default {
         });
       }
     },
+
   },
 };
 </script>

--- a/web/src/lang/en.js
+++ b/web/src/lang/en.js
@@ -380,4 +380,15 @@ export default {
   role_required: 'Role is required',
 
   templatePermission: 'Template permissions',
+
+  // Additional Repositories
+  additionalRepositories: 'Additional Repositories',
+  pathInvalidCharacters: 'Path can only contain letters, numbers, dashes, underscores, and slashes',
+  pathAlreadyUsed: 'This path is already used by another repository',
+  exampleMyRepo: 'e.g., my-repo or libs/my-lib',
+  optional: 'Optional',
+  additionalRepositoryBranches: 'Additional Repository Branches (Override)',
+  setBranch: 'Set branch',
+  useDefaultBranch: 'Use default',
+  clearAdditionalRepositories: 'Clear additional repositories directory before build',
 };

--- a/web/src/lang/pl.js
+++ b/web/src/lang/pl.js
@@ -345,4 +345,15 @@ export default {
   project_stats: 'Statystyki',
   allow_override_branch: 'Gałąź',
   template_common_options: 'Wspólne opcje',
+
+  // Dodatkowe repozytoria
+  additionalRepositories: 'Dodatkowe repozytoria',
+  pathInvalidCharacters: 'Ścieżka może zawierać tylko litery, cyfry, myślniki, podkreślenia i ukośniki',
+  pathAlreadyUsed: 'Ta ścieżka jest już używana przez inne repozytorium',
+  exampleMyRepo: 'np. moje-repo lub libs/moja-lib',
+  optional: 'Opcjonalnie',
+  additionalRepositoryBranches: 'Gałęzie dodatkowych repozytoriów (nadpisanie)',
+  setBranch: 'Wybierz gałąź',
+  useDefaultBranch: 'Użyj domyślny',
+  clearAdditionalRepositories: 'Wyczyść katalog dodatkowych repozytoriów przed budowaniem',
 };


### PR DESCRIPTION
This change allows tasks to clone multiple git repositories alongside the main repository during execution. Additional repos are cloned into `<workspace>/repos/` subdirectory with configurable paths.

 Use case: Projects requiring dependencies from multiple repositories (e.g., shared libraries, configuration repos, get project code to build or external modules) can now be automatically cloned and available during task execution without manual scripting.

<img width="763" height="960" alt="image" src="https://github.com/user-attachments/assets/0bcd0931-bba3-4f45-8a58-e50782e22946" />

<img width="433" height="414" alt="image" src="https://github.com/user-attachments/assets/ab78daa8-97be-4b90-8a87-cc6453afe141" />

