### PR TITLE
ssh-agent task keys

### DIFF
--- a/db/Template.go
+++ b/db/Template.go
@@ -76,6 +76,7 @@ type AnsibleTemplateParams struct {
 	Limit                  []string `json:"limit"`
 	Tags                   []string `json:"tags"`
 	SkipTags               []string `json:"skip_tags"`
+	SSHAgentKeyIDs         []int    `json:"ssh_agent_key_ids,omitempty"`
 }
 
 type TerraformTemplateParams struct {
@@ -84,6 +85,11 @@ type TerraformTemplateParams struct {
 	AutoApprove      bool   `json:"auto_approve,omitempty"`
 	OverrideBackend  bool   `json:"override_backend,omitempty"` // override backend if internal backend is used
 	BackendFilename  string `json:"backend_filename,omitempty"`
+	SSHAgentKeyIDs   []int  `json:"ssh_agent_key_ids,omitempty"`
+}
+
+type DefaultTemplateParams struct {
+	SSHAgentKeyIDs []int `json:"ssh_agent_key_ids,omitempty"`
 }
 
 type SurveyVarEnumValue struct {

--- a/pkg/ssh/agent.go
+++ b/pkg/ssh/agent.go
@@ -134,6 +134,40 @@ func StartSSHAgent(key db.AccessKey, logger task_logger.Logger) (Agent, error) {
 	return sshAgent, sshAgent.Listen()
 }
 
+func StartSSHAgentWithKeys(keys []db.AccessKey, projectID int, logger task_logger.Logger) (Agent, error) {
+	if len(keys) == 0 {
+		return Agent{}, fmt.Errorf("no keys provided")
+	}
+
+	// Generate unique socket filename
+	socketFilename := fmt.Sprintf("ssh-agent-process-%s.sock", random.String(10))
+	socketFile := path.Join(util.Config.GetProjectTmpDir(projectID), socketFilename)
+
+	// Build agent keys array
+	var agentKeys []AgentKey
+	for _, key := range keys {
+		if key.Type != db.AccessKeySSH {
+			continue // Skip non-SSH keys
+		}
+		agentKeys = append(agentKeys, AgentKey{
+			Key:        []byte(key.SshKey.PrivateKey),
+			Passphrase: []byte(key.SshKey.Passphrase),
+		})
+	}
+
+	if len(agentKeys) == 0 {
+		return Agent{}, fmt.Errorf("no valid SSH keys found")
+	}
+
+	sshAgent := Agent{
+		Logger:     logger,
+		Keys:       agentKeys,
+		SocketFile: socketFile,
+	}
+
+	return sshAgent, sshAgent.Listen()
+}
+
 type AccessKeyInstallation struct {
 	SSHAgent *Agent
 	Login    string

--- a/services/tasks/LocalJob.go
+++ b/services/tasks/LocalJob.go
@@ -15,6 +15,7 @@ import (
 	"github.com/semaphoreui/semaphore/db"
 	"github.com/semaphoreui/semaphore/db_lib"
 	"github.com/semaphoreui/semaphore/pkg/task_logger"
+	"github.com/semaphoreui/semaphore/services/server"
 	"github.com/semaphoreui/semaphore/util"
 )
 
@@ -36,7 +37,9 @@ type LocalJob struct {
 	becomeKeyInstallation  ssh.AccessKeyInstallation
 	vaultFileInstallations map[string]ssh.AccessKeyInstallation
 
-	KeyInstaller db_lib.AccessKeyInstaller
+	KeyInstaller       db_lib.AccessKeyInstaller
+	store              db.Store
+	encryptionService  server.AccessKeyEncryptionService
 }
 
 func (t *LocalJob) IsKilled() bool {
@@ -628,6 +631,31 @@ func (t *LocalJob) getParams() (params any, err error) {
 	}
 
 	return
+}
+
+// getProcessSSHKeyIDs extracts SSH Agent key IDs from template params
+func (t *LocalJob) getProcessSSHKeyIDs() ([]int, error) {
+	switch t.Template.App {
+	case db.AppAnsible:
+		var params db.AnsibleTemplateParams
+		if err := t.Template.FillParams(&params); err != nil {
+			return nil, err
+		}
+		return params.SSHAgentKeyIDs, nil
+	case db.AppTerraform, db.AppTofu, db.AppTerragrunt:
+		var params db.TerraformTemplateParams
+		if err := t.Template.FillParams(&params); err != nil {
+			return nil, err
+		}
+		return params.SSHAgentKeyIDs, nil
+	default:
+		// For other apps (bash, powershell, python, pulumi), use DefaultTemplateParams
+		var params db.DefaultTemplateParams
+		if err := t.Template.FillParams(&params); err != nil {
+			return nil, err
+		}
+		return params.SSHAgentKeyIDs, nil
+	}
 }
 
 func (t *LocalJob) Run(username string, incomingVersion *string, alias string) (err error) {

--- a/services/tasks/LocalJob_inventory.go
+++ b/services/tasks/LocalJob_inventory.go
@@ -1,23 +1,81 @@
 package tasks
 
 import (
+	"fmt"
 	"os"
 	"path"
 	"strconv"
 
 	"github.com/semaphoreui/semaphore/db"
 	"github.com/semaphoreui/semaphore/db_lib"
+	"github.com/semaphoreui/semaphore/pkg/ssh"
 	log "github.com/sirupsen/logrus"
 
 	"github.com/semaphoreui/semaphore/util"
 )
 
 func (t *LocalJob) installInventory() (err error) {
-	if t.Inventory.SSHKeyID != nil {
-		t.sshKeyInstallation, err = t.KeyInstaller.Install(t.Inventory.SSHKey, db.AccessKeyRoleAnsibleUser, t.Logger)
+	processKeyIDs, err := t.getProcessSSHKeyIDs()
+	if err != nil {
+		return err
+	}
+
+	var processKeys []db.AccessKey
+	for _, keyID := range processKeyIDs {
+		key, err := t.store.GetAccessKey(t.Template.ProjectID, keyID)
 		if err != nil {
-			return
+			return fmt.Errorf("failed to load process SSH key %d: %w", keyID, err)
 		}
+
+		if err := t.encryptionService.DeserializeSecret(&key); err != nil {
+			return fmt.Errorf("failed to deserialize process SSH key %d: %w", keyID, err)
+		}
+
+		if key.Type != db.AccessKeySSH {
+			return fmt.Errorf("process key %d is not an SSH key (type: %s)", keyID, key.Type)
+		}
+
+		processKeys = append(processKeys, key)
+	}
+
+	if t.Inventory.SSHKeyID != nil {
+		if t.Inventory.SSHKey.Type == db.AccessKeySSH && len(processKeys) > 0 {
+			// Both inventory key and process keys - combine them
+			allKeys := append([]db.AccessKey{t.Inventory.SSHKey}, processKeys...)
+			agent, err := ssh.StartSSHAgentWithKeys(allKeys, t.Template.ProjectID, t.Logger)
+			if err != nil {
+				return fmt.Errorf("failed to start SSH agent with combined keys: %w", err)
+			}
+			t.sshKeyInstallation.SSHAgent = &agent
+			t.sshKeyInstallation.Login = t.Inventory.SSHKey.SshKey.Login
+			t.Log(fmt.Sprintf("Started SSH Agent with inventory key + %d process key(s)", len(processKeys)))
+		} else if len(processKeys) > 0 {
+			t.sshKeyInstallation, err = t.KeyInstaller.Install(t.Inventory.SSHKey, db.AccessKeyRoleAnsibleUser, t.Logger)
+			if err != nil {
+				return err
+			}
+			agent, err := ssh.StartSSHAgentWithKeys(processKeys, t.Template.ProjectID, t.Logger)
+			if err != nil {
+				return fmt.Errorf("failed to start SSH agent with process keys: %w", err)
+			}
+			if t.sshKeyInstallation.SSHAgent != nil {
+				t.sshKeyInstallation.SSHAgent.Close()
+			}
+			t.sshKeyInstallation.SSHAgent = &agent
+			t.Log(fmt.Sprintf("Started SSH Agent with %d process key(s)", len(processKeys)))
+		} else {
+			t.sshKeyInstallation, err = t.KeyInstaller.Install(t.Inventory.SSHKey, db.AccessKeyRoleAnsibleUser, t.Logger)
+			if err != nil {
+				return err
+			}
+		}
+	} else if len(processKeys) > 0 {
+		agent, err := ssh.StartSSHAgentWithKeys(processKeys, t.Template.ProjectID, t.Logger)
+		if err != nil {
+			return fmt.Errorf("failed to start SSH agent with process keys: %w", err)
+		}
+		t.sshKeyInstallation.SSHAgent = &agent
+		t.Log(fmt.Sprintf("Started SSH Agent with %d process key(s)", len(processKeys)))
 	}
 
 	if t.Inventory.BecomeKeyID != nil {

--- a/services/tasks/TaskPool.go
+++ b/services/tasks/TaskPool.go
@@ -390,15 +390,17 @@ func (p *TaskPool) hydrateTaskRunner(taskID int, projectID int) (*TaskRunner, er
 	} else {
 		app := db_lib.CreateApp(tr.Template, tr.Repository, tr.Inventory, tr)
 		job = &LocalJob{
-			Task:         tr.Task,
-			Template:     tr.Template,
-			Inventory:    tr.Inventory,
-			Repository:   tr.Repository,
-			Environment:  tr.Environment,
-			Secret:       "{}",
-			Logger:       app.SetLogger(tr),
-			App:          app,
-			KeyInstaller: p.keyInstallationService,
+			Task:              tr.Task,
+			Template:          tr.Template,
+			Inventory:         tr.Inventory,
+			Repository:        tr.Repository,
+			Environment:       tr.Environment,
+			Secret:            "{}",
+			Logger:            app.SetLogger(tr),
+			App:               app,
+			KeyInstaller:      p.keyInstallationService,
+			store:             p.store,
+			encryptionService: p.encryptionService,
 		}
 	}
 	tr.job = job
@@ -728,15 +730,17 @@ func (p *TaskPool) AddTask(
 			taskRunner)
 
 		job = &LocalJob{
-			Task:         taskRunner.Task,
-			Template:     taskRunner.Template,
-			Inventory:    taskRunner.Inventory,
-			Repository:   taskRunner.Repository,
-			Environment:  taskRunner.Environment,
-			Secret:       extraSecretVars,
-			Logger:       app.SetLogger(taskRunner),
-			App:          app,
-			KeyInstaller: p.keyInstallationService,
+			Task:              taskRunner.Task,
+			Template:          taskRunner.Template,
+			Inventory:         taskRunner.Inventory,
+			Repository:        taskRunner.Repository,
+			Environment:       taskRunner.Environment,
+			Secret:            extraSecretVars,
+			Logger:            app.SetLogger(taskRunner),
+			App:               app,
+			KeyInstaller:      p.keyInstallationService,
+			store:             p.store,
+			encryptionService: p.encryptionService,
 		}
 	}
 

--- a/web/src/components/TemplateForm.vue
+++ b/web/src/components/TemplateForm.vue
@@ -292,6 +292,47 @@
             @change="setSurveyVars"
           />
 
+          <v-autocomplete
+            v-if="sshKeys != null && supportsSSHAgent"
+            v-model="ssh_agent_key_ids"
+            :items="sshKeys"
+            item-value="id"
+            item-text="name"
+            :label="$t('sshAgentKeys')"
+            :hint="$t('sshAgentKeysHint')"
+            persistent-hint
+            multiple
+            chips
+            deletable-chips
+            outlined
+            dense
+            class="mb-3"
+          >
+            <template v-slot:selection="{ item, index }">
+              <v-chip
+                v-if="index < 2"
+                close
+                @click:close="removeSSHAgentKey(item.id)"
+                small
+              >
+                {{ item.name }}
+              </v-chip>
+              <span
+                v-if="index === 2"
+                class="grey--text text-caption"
+              >
+                (+{{ ssh_agent_key_ids.length - 2 }} {{ $t('others') }})
+              </span>
+            </template>
+          </v-autocomplete>
+
+          <v-skeleton-loader
+            v-else-if="supportsSSHAgent"
+            type="card"
+            height="54"
+            style="margin-bottom: 16px; margin-top: 4px;"
+          ></v-skeleton-loader>
+
           <v-checkbox
             class="mt-0"
             v-model="item.allow_parallel_tasks"
@@ -590,6 +631,7 @@ export default {
       runnerTags: null,
       branches: null,
       setBranch: false,
+      keys: null,
     };
   },
 
@@ -650,6 +692,26 @@ export default {
       },
       set(newValue) {
         this.item.task_params.allow_override_inventory = newValue;
+      },
+    },
+
+    sshKeys() {
+      if (this.keys == null) {
+        return null;
+      }
+      return this.keys.filter((key) => key.type === 'ssh');
+    },
+
+    supportsSSHAgent() {
+      return ['ansible', 'terraform', 'tofu', 'terragrunt', 'bash', 'powershell', 'python', 'pulumi'].includes(this.app);
+    },
+
+    ssh_agent_key_ids: {
+      get() {
+        return this.item.task_params.ssh_agent_key_ids || [];
+      },
+      set(newValue) {
+        this.item.task_params.ssh_agent_key_ids = newValue;
       },
     },
 
@@ -764,6 +826,13 @@ export default {
       this.item.vaults = v;
     },
 
+    removeSSHAgentKey(keyId) {
+      const index = this.ssh_agent_key_ids.indexOf(keyId);
+      if (index > -1) {
+        this.ssh_agent_key_ids = this.ssh_agent_key_ids.filter((id) => id !== keyId);
+      }
+    },
+
     showHelpDialog(key) {
       this.helpKey = key;
       this.helpDialog = true;
@@ -789,6 +858,7 @@ export default {
         this.environment,
         templates,
         this.runnerTags,
+        this.keys,
       ] = await Promise.all([
         this.loadProjectResources('repositories'),
         this.loadProjectEndpoint(`/inventory?app=${this.app}&template_id=${this.itemId}`),
@@ -798,6 +868,7 @@ export default {
         this.loadProjectResources('environment'),
         this.loadProjectResources('templates'),
         this.loadProjectResources('runner_tags'),
+        this.loadProjectResources('keys'),
       ]);
 
       this.inventory = [...inventory1, ...inventory2];

--- a/web/src/lang/en.js
+++ b/web/src/lang/en.js
@@ -346,6 +346,10 @@ export default {
   tags: 'Tags',
   limit: 'Limit',
 
+  sshAgentKeys: 'SSH Agent Keys',
+  sshAgentKeysHint: 'SSH keys to load into SSH Agent during task execution. Enables automatic SSH authentication for git clone and other SSH operations.',
+  others: 'others',
+
   runner_tag: 'Runner tag',
   allow_parallel_tasks: 'Allow parallel tasks',
   task_prompts: 'Prompts',

--- a/web/src/lang/pl.js
+++ b/web/src/lang/pl.js
@@ -335,6 +335,10 @@ export default {
   tags: 'Tagi',
   limit: 'Limit',
 
+  sshAgentKeys: 'Klucze SSH Agent',
+  sshAgentKeysHint: 'Klucze SSH do załadowania do SSH Agent podczas wykonywania taska. Umożliwia automatyczną autentykację SSH dla git clone i innych operacji SSH.',
+  others: 'innych',
+
   runner_tag: 'Tag uruchamiacza',
   task_prompts: 'Podpowiedzi',
   template_advanced: 'Opcje zaawansowane',


### PR DESCRIPTION
This change allows to choose extra ssh-keys to load into SSH Agent during task execution. The key benefit is that instead of mounting SSH keys into the container's filesystem (~/.ssh/), the keys are securely loaded into an SSH Agent, which is a more secure and flexible approach for handling SSH authentication in containerized environments.