### PR TITLE
Better localization of log times

### DIFF
--- a/web/src/main.js
+++ b/web/src/main.js
@@ -70,7 +70,7 @@ Vue.filter('formatDate', (value) => {
 });
 
 // formatTime: localized time with seconds
-Vue.filter('formatTime', (value) => (value ? dayjs(String(value)).format('LTS') : '—'));
+Vue.filter('formatTime', (value) => (value ? new Date(value).toLocaleTimeString(undefined, { hour: 'numeric', minute: 'numeric' }) : '—'));
 
 // formatLog: unchanged (ANSI → HTML)
 Vue.filter('formatLog', (value) => (value ? convert.ansi_to_html(String(value)) : value));

--- a/web/src/main.js
+++ b/web/src/main.js
@@ -70,7 +70,7 @@ Vue.filter('formatDate', (value) => {
 });
 
 // formatTime: localized time with seconds
-Vue.filter('formatTime', (value) => (value ? new Date(value).toLocaleTimeString(undefined, { hour: 'numeric', minute: 'numeric' }) : '—'));
+Vue.filter('formatTime', (value) => (value ? new Date(value).toLocaleTimeString(undefined, { hour: "2-digit", minute: "2-digit", second: "2-digit" }) : '—'));
 
 // formatLog: unchanged (ANSI → HTML)
 Vue.filter('formatLog', (value) => (value ? convert.ansi_to_html(String(value)) : value));

--- a/web/src/main.js
+++ b/web/src/main.js
@@ -70,7 +70,7 @@ Vue.filter('formatDate', (value) => {
 });
 
 // formatTime: localized time with seconds
-Vue.filter('formatTime', (value) => (value ? new Date(value).toLocaleTimeString(undefined, { hour: "2-digit", minute: "2-digit", second: "2-digit" }) : '—'));
+Vue.filter('formatTime', (value) => (value ? new Date(value).toLocaleTimeString(undefined, { hour: '2-digit', minute: '2-digit', second: '2-digit' }) : '—'));
 
 // formatLog: unchanged (ANSI → HTML)
 Vue.filter('formatLog', (value) => (value ? convert.ansi_to_html(String(value)) : value));


### PR DESCRIPTION
Currently, for us, logs show times like "03:12:02 PM", while we're in Europe.

This seems to be a limitation of dayjs, where it doesn't "localize" at all, it just tacks on AM/PM when it uses `LTS` as a format;
- https://github.com/iamkun/dayjs/issues/1346
- https://day.js.org/docs/en/display/format#list-of-localized-formats (`LTS` -> `h:mm:ss A`)
- Locales need to be explicitly set globally, which I couldn't find/see happening anywhere.

So this uses the browser locale to define the time format.