### PR TITLE
Make task parameters always visible in the details tab

### DIFF
--- a/web/src/components/TaskDetails.vue
+++ b/web/src/components/TaskDetails.vue
@@ -111,7 +111,6 @@
       </v-col>
       <v-col cols="12" md="6">
         <v-card
-          v-if="item?.params"
           :color="$vuetify.theme.dark ? '#212121' : 'white'"
           style="background: #8585850f"
           class="mb-5"


### PR DESCRIPTION
Fixes #3561

This can also reduce confusion, as IMO hiding the task parameters part when it's all-default is not useful for determining "but did this task *really* get launched without diff/check, or is this view just hiding that information from me because it's sensitive?"; at no part is it properly communicated that `hidden == default parameters`, and imo on a detail screen with as much information as possible, you don't want to hide any extra bits