### PR TITLE
Add semaphore task details to shell apps as environment variables

### DIFF
--- a/services/tasks/LocalJob.go
+++ b/services/tasks/LocalJob.go
@@ -71,18 +71,8 @@ func (t *LocalJob) SetCommit(hash, message string) {
 	t.Logger.SetCommit(hash, message)
 }
 
-func (t *LocalJob) getEnvironmentExtraVars(username string, incomingVersion *string) (extraVars map[string]any, err error) {
-
-	extraVars = make(map[string]any)
-
-	if t.Environment.JSON != "" {
-		err = json.Unmarshal([]byte(t.Environment.JSON), &extraVars)
-		if err != nil {
-			return
-		}
-	}
-
-	taskDetails := make(map[string]any)
+func (t *LocalJob) getTaskDetails(username string, incomingVersion *string) (taskDetails map[string]any) {
+	taskDetails = make(map[string]any)
 
 	taskDetails["id"] = t.Task.ID
 
@@ -109,8 +99,22 @@ func (t *LocalJob) getEnvironmentExtraVars(username string, incomingVersion *str
 		}
 	}
 
+	return
+}
+
+func (t *LocalJob) getEnvironmentExtraVars(username string, incomingVersion *string) (extraVars map[string]any, err error) {
+
+	extraVars = make(map[string]any)
+
+	if t.Environment.JSON != "" {
+		err = json.Unmarshal([]byte(t.Environment.JSON), &extraVars)
+		if err != nil {
+			return
+		}
+	}
+
 	vars := make(map[string]any)
-	vars["task_details"] = taskDetails
+	vars["task_details"] = t.getTaskDetails(username, incomingVersion)
 	extraVars["semaphore_vars"] = vars
 
 	return
@@ -136,35 +140,8 @@ func (t *LocalJob) getEnvironmentExtraVarsJSON(username string, incomingVersion 
 
 	maps.Copy(extraVars, extraSecretVars)
 
-	taskDetails := make(map[string]any)
-
-	taskDetails["id"] = t.Task.ID
-
-	if t.Task.Message != "" {
-		taskDetails["message"] = t.Task.Message
-	}
-
-	taskDetails["username"] = username
-	taskDetails["url"] = t.Task.GetUrl()
-	taskDetails["commit_hash"] = t.Task.CommitHash
-	taskDetails["commit_message"] = t.Task.CommitMessage
-	taskDetails["inventory_name"] = t.Inventory.Name
-	taskDetails["inventory_id"] = t.Inventory.ID
-	taskDetails["repository_name"] = t.Repository.Name
-	taskDetails["repository_id"] = t.Repository.ID
-
-	if t.Template.Type != db.TemplateTask {
-		taskDetails["type"] = t.Template.Type
-		if incomingVersion != nil {
-			taskDetails["incoming_version"] = incomingVersion
-		}
-		if t.Template.Type == db.TemplateBuild {
-			taskDetails["target_version"] = t.Task.Version
-		}
-	}
-
 	vars := make(map[string]any)
-	vars["task_details"] = taskDetails
+	vars["task_details"] = t.getTaskDetails(username, incomingVersion)
 	extraVars["semaphore_vars"] = vars
 
 	ev, err := json.Marshal(extraVars)

--- a/services/tasks/LocalJob.go
+++ b/services/tasks/LocalJob.go
@@ -178,6 +178,22 @@ func (t *LocalJob) getEnvironmentENV() (res []string, err error) {
 	return
 }
 
+func (t *LocalJob) getShellEnvironmentExtraENV(username string, incomingVersion *string) (extraShellVars []string) {
+	taskDetails := t.getTaskDetails(username, incomingVersion)
+
+	for taskDetail, taskDetailValue := range taskDetails {
+		detailAsStr, ok := taskDetailValue.(string)
+		if !ok {
+			continue
+		}
+
+		envVarName := fmt.Sprintf("SEMAPHORE_TASK_DETAILS_%s", strings.ToUpper(taskDetail))
+		extraShellVars = append(extraShellVars, fmt.Sprintf("%s=%s", envVarName, detailAsStr))
+	}
+
+	return
+}
+
 // nolint: gocyclo
 func (t *LocalJob) getShellArgs(username string, incomingVersion *string) (args []string, err error) {
 	extraVars, err := t.getEnvironmentExtraVars(username, incomingVersion)
@@ -705,6 +721,18 @@ func (t *LocalJob) Run(username string, incomingVersion *string, alias string) (
 		}
 		// Convert to map format with "default" key
 		argsMap = map[string][]string{"default": args}
+	}
+
+	// Get extra environment vars for non-Terraform apps
+	switch t.Template.App {
+	case db.AppAnsible:
+		// Semaphore vars / task details were already passed
+		// as 'extra vars' in JSON format
+		break
+	case db.AppTerraform, db.AppTofu, db.AppTerragrunt:
+		break
+	default:
+		environmentVariables = append(environmentVariables, t.getShellEnvironmentExtraENV(username, incomingVersion)...)
 	}
 
 	if t.Inventory.SSHKey.Type == db.AccessKeySSH && t.Inventory.SSHKeyID != nil {

--- a/services/tasks/LocalJob.go
+++ b/services/tasks/LocalJob.go
@@ -205,7 +205,7 @@ func (t *LocalJob) getShellEnvironmentExtraENV(username string, incomingVersion 
 		}
 
 		if detailAsStr != "" {
-			extraShellVars = append(extraShellVars, fmt.Sprintf("%s=%s", envVarName, detailAsStr))
+			extraShellVars = append(extraShellVars, fmt.Sprintf("%s=%s", envVarName, util.ShellQuote(util.ShellStripUnsafe(detailAsStr))))
 		}
 	}
 

--- a/services/tasks/LocalJob.go
+++ b/services/tasks/LocalJob.go
@@ -182,13 +182,31 @@ func (t *LocalJob) getShellEnvironmentExtraENV(username string, incomingVersion 
 	taskDetails := t.getTaskDetails(username, incomingVersion)
 
 	for taskDetail, taskDetailValue := range taskDetails {
-		detailAsStr, ok := taskDetailValue.(string)
-		if !ok {
+		envVarName := fmt.Sprintf("SEMAPHORE_TASK_DETAILS_%s", strings.ToUpper(taskDetail))
+
+		detailAsStr := ""
+		switch taskDetailValueOfType := taskDetailValue.(type) {
+		case string:
+			detailAsStr = taskDetailValueOfType
+		case *string:
+			if taskDetailValueOfType != nil {
+				detailAsStr = *taskDetailValueOfType
+			}
+
+		case int:
+			detailAsStr = strconv.Itoa(taskDetailValueOfType)
+		case *int:
+			if taskDetailValueOfType != nil {
+				detailAsStr = strconv.Itoa(*taskDetailValueOfType)
+			}
+
+		default:
 			continue
 		}
 
-		envVarName := fmt.Sprintf("SEMAPHORE_TASK_DETAILS_%s", strings.ToUpper(taskDetail))
-		extraShellVars = append(extraShellVars, fmt.Sprintf("%s=%s", envVarName, detailAsStr))
+		if detailAsStr != "" {
+			extraShellVars = append(extraShellVars, fmt.Sprintf("%s=%s", envVarName, detailAsStr))
+		}
 	}
 
 	return

--- a/util/shell.go
+++ b/util/shell.go
@@ -1,0 +1,43 @@
+package util
+
+import (
+	"regexp"
+	"strings"
+	"unicode"
+)
+
+// Imported from https://github.com/alessio/shellescape/blob/master/shellescape.go
+// Credits goes to https://github.com/alessio/shellescape maintainers
+
+var shellQuotePattern *regexp.Regexp
+
+func init() {
+	shellQuotePattern = regexp.MustCompile(`[^\w@%+=:,./-]`)
+}
+
+// Quote returns a shell-escaped version of the string s. The returned value
+// is a string that can safely be used as one token in a shell command line.
+func ShellQuote(s string) string {
+	if len(s) == 0 {
+		return "''"
+	}
+
+	if shellQuotePattern.MatchString(s) {
+		return "'" + strings.ReplaceAll(s, "'", "'\"'\"'") + "'"
+	}
+
+	return s
+}
+
+// StripUnsafe remove non-printable runes, e.g. control characters in
+// a string that is meant  for consumption by terminals that support
+// control characters.
+func ShellStripUnsafe(s string) string {
+	return strings.Map(func(r rune) rune {
+		if unicode.IsPrint(r) {
+			return r
+		}
+
+		return -1
+	}, s)
+}


### PR DESCRIPTION
Hi,

## Description

This P.R adds support for passing _Semaphore task details_ as _extra environment variables_ to _shell apps_.

Shell apps should see new environment variables such as `SEMAPHORE_TASK_DETAILS_ID`, `SEMAPHORE_TASK_DETAILS_URL`, etc...

## Motivation

For tracing purpose, we're passing all the _semaphore context_ we can to our applications. This _tracing context_ ends up in _ElasticSearch_.

We currently extract all the information we can about the _Semaphore Task_ from the _current working directory_ that looks like `/tmp/semaphore/project_1/repository_4_template_15` (or equivalent) with a _dumb regular expression_ to extra `projectID`, `repositoryID` and `templateID`.

We'd really benefit to have access to the `taskID` and more generally to all the _task details_ Semaphore can provide.

Regards