### PR TITLE
Added host limit values in Task parameters instead of just Yes

### DIFF
--- a/web/src/components/TaskDetails.vue
+++ b/web/src/components/TaskDetails.vue
@@ -130,7 +130,9 @@
                 <tr>
                   <td><b>Limit</b></td>
                   <td>
-                    {{ item.params.limit ? 'Yes' : 'No' }}
+                    <span v-if="Array.isArray(item.params.limit) && item.params.limit.length > 0">
+                      {{ item.params.limit.join(', ') }}</span>
+                    <span v-else>'No'</span>
                   </td>
                 </tr>
                 <tr>


### PR DESCRIPTION
The Task parameters section in Task details for previously ran jobs simply stated 'Yes' or 'No' if a limit value was used, this change lists the actual limit values that were used (basic comma separation) and keeps 'No' if none were used. This information is useful for organizations (including ours) that have auditing requirements.