### PR TITLE
fix: fixed a race condition for terraform task statuses

### DIFF
--- a/services/runners/job_pool.go
+++ b/services/runners/job_pool.go
@@ -598,7 +598,7 @@ func (p *JobPool) checkNewJobs() {
 
 		switch runJob.status {
 		case task_logger.TaskRunningStatus:
-			if currJob.Status == task_logger.TaskStartingStatus || currJob.Status == task_logger.TaskWaitingStatus {
+			if currJob.Status == task_logger.TaskStartingStatus || currJob.Status == task_logger.TaskWaitingStatus || currJob.Status == task_logger.TaskConfirmed {
 				continue
 			}
 		case task_logger.TaskStoppingStatus:
@@ -607,6 +607,10 @@ func (p *JobPool) checkNewJobs() {
 			}
 		case task_logger.TaskConfirmed:
 			if currJob.Status == task_logger.TaskWaitingConfirmation {
+				continue
+			}
+		case task_logger.TaskWaitingConfirmation:
+			if currJob.Status == task_logger.TaskRunningStatus {
 				continue
 			}
 		}


### PR DESCRIPTION
## PR Title

Fix race condition in runner task status sync causing incorrect confirmation state for Terraform tasks

## Description

This PR fixes a race condition in the runner that could overwrite task confirmation statuses during synchronization with the server.

## Observed problem

When using **separate runners** and executing **Terraform tasks**, there were situations where the task should transition to the **"waiting for confirmation"** state after `terraform plan` detects infrastructure changes.

However, the task remained in the **"running"** state even though the logs clearly showed that Terraform had finished the plan phase and was waiting for confirmation.

As a result:

* the task never transitioned to the confirmation state in the UI
* the infrastructure update could not be approved
* the task had to be **restarted multiple times** until the confirmation state eventually appeared

This behavior was intermittent and difficult to reproduce reliably.

## Root cause

The runner uses two concurrent goroutines:

1. **Status sync goroutine** — periodically fetches task statuses from the server and updates local task states if they differ.
2. **Reporting goroutine** — collects local task states and logs and sends them back to the server.

A race condition could occur in the following scenario:

1. A task running on the runner transitions to the **"waiting for confirmation"** state.
2. At the same time, the status sync goroutine fetches task states from the server where the task is still **"running"**.
3. Because the statuses differ, the runner overwrites the local task status with the server status (`running`).
4. Immediately after that, the reporting goroutine sends the current task states back to the server.

As a result, instead of sending the expected **"waiting for confirmation"** status, the runner sends **"running"**, effectively losing the confirmation state.

## Additional issue

A similar race condition also affected the **"confirmed"** status.
In this case the issue was mostly **visual** and did not affect actual task execution, but the root cause was the same concurrent state overwrite.

## Solution

The fix ensures that task status updates from the server do not overwrite local runner states that have already transitioned to confirmation-related statuses.

This prevents the runner from reverting task states when synchronization happens concurrently with local state transitions.

## Result

* Eliminates the race condition between status synchronization and reporting
* Prevents loss of **"waiting for confirmation"** state
* Fixes incorrect **"confirmed"** status display
* Ensures Terraform confirmation workflow works reliably
