### PR TITLE
Fix typo in conditional check for SEMAPHORE_IMPORT_PROJECT_FILE

### DIFF
--- a/deployment/docker/server/server-wrapper
+++ b/deployment/docker/server/server-wrapper
@@ -292,7 +292,7 @@ fi
 
 # Import project if environment variable SEMAPHORE_IMPORT_PROJECT_FILE is defined.
 # Optionally use SEMAPHORE_IMPORT_PROJECT_NAME to specify the project name.
-if [ -n "${SEMAPHORE_IMPORT_PROJECT_FILE:-}" ]; && [ "${SEMAPHORE_FIRST_RUN}" = "yes" ]; then
+if [ -n "${SEMAPHORE_IMPORT_PROJECT_FILE:-}" ] && [ "${SEMAPHORE_FIRST_RUN}" = "yes" ]; then
     echoerr "Importing project from ${SEMAPHORE_IMPORT_PROJECT_FILE}"
     IMPORT_ARGS="--file ${SEMAPHORE_IMPORT_PROJECT_FILE}"
     if [ -n "${SEMAPHORE_IMPORT_PROJECT_NAME:-}" ]; then


### PR DESCRIPTION
There was a small typo in the server-wrapper.

resulting in this error:
```
/usr/local/bin/server-wrapper: line 295: syntax error: unexpected "&&"
```