### PR TITLE
Add admin permission check for project restore from backup

### DIFF
--- a/api/projects/backup_restore.go
+++ b/api/projects/backup_restore.go
@@ -39,7 +39,7 @@ func Restore(w http.ResponseWriter, r *http.Request) {
 	user := helpers.GetFromContext(r, "user").(*db.User)
 
 	if !user.Admin && !util.Config.NonAdminCanCreateProject {
-		log.Warn(user.Username + " is not permitted to to restore the project")
+		log.Warn(user.Username + " is not permitted to restore the project")
 		w.WriteHeader(http.StatusUnauthorized)
 		return
 	}

--- a/api/projects/backup_restore.go
+++ b/api/projects/backup_restore.go
@@ -1,6 +1,7 @@
 package projects
 
 import (
+	"github.com/semaphoreui/semaphore/util"
 	"io"
 	"net/http"
 	"strings"
@@ -36,6 +37,12 @@ func GetBackup(w http.ResponseWriter, r *http.Request) {
 
 func Restore(w http.ResponseWriter, r *http.Request) {
 	user := helpers.GetFromContext(r, "user").(*db.User)
+
+	if !user.Admin && !util.Config.NonAdminCanCreateProject {
+		log.Warn(user.Username + " is not permitted to edit users")
+		w.WriteHeader(http.StatusUnauthorized)
+		return
+	}
 
 	var backup projectService.BackupFormat
 

--- a/api/projects/backup_restore.go
+++ b/api/projects/backup_restore.go
@@ -39,7 +39,7 @@ func Restore(w http.ResponseWriter, r *http.Request) {
 	user := helpers.GetFromContext(r, "user").(*db.User)
 
 	if !user.Admin && !util.Config.NonAdminCanCreateProject {
-		log.Warn(user.Username + " is not permitted to edit users")
+		log.Warn(user.Username + " is not permitted to to restore the project")
 		w.WriteHeader(http.StatusUnauthorized)
 		return
 	}


### PR DESCRIPTION
## PR Title

Add admin permission check for project restore from backup

## Description

This PR adds a missing **admin permission check** when restoring a project from backup.

## Problem

In the current implementation, creating a new project correctly requires **admin privileges**.
However, the **project restore from backup** endpoint did not perform the same permission check.

As a result, a non-admin user could restore a project from a backup and effectively create a new project without having the required permissions.

This created a permission bypass scenario:

* non-admin users **cannot create projects directly**
* but they **could restore a project from backup**, which results in a new project being created

## Solution

This PR adds the same **admin permission validation** used in project creation to the **project restore** operation.

Now:

* only users with **admin privileges** can restore a project from backup
* permission checks are consistent with the normal project creation flow

## Result

* Prevents permission bypass via project restore
