### PR TITLE
fix(config): validate access_key_encryption at startup

### DIFF
--- a/util/config.go
+++ b/util/config.go
@@ -969,9 +969,34 @@ func validate(value any) error {
 	return nil
 }
 
+func validateAccessKeyEncryption(key string) error {
+	if key == "" {
+		return nil
+	}
+
+	encryption, err := base64.StdEncoding.DecodeString(key)
+	if err != nil {
+		return fmt.Errorf("access_key_encryption must be a valid base64 string: %w", err)
+	}
+
+	switch len(encryption) {
+	case 16, 24, 32:
+		return nil
+	default:
+		return fmt.Errorf(
+			"access_key_encryption has invalid decoded length %d bytes; AES requires 16, 24, or 32 bytes (use `openssl rand -base64 32` to generate a valid key)",
+			len(encryption),
+		)
+	}
+}
+
 func validateConfig() {
 	err := validate(Config)
 	if err != nil {
+		panic(err)
+	}
+
+	if err := validateAccessKeyEncryption(Config.AccessKeyEncryption); err != nil {
 		panic(err)
 	}
 }

--- a/util/config_test.go
+++ b/util/config_test.go
@@ -417,4 +417,21 @@ func TestValidateConfig(t *testing.T) {
 	Config.Dialect = "someOtherDB"
 	ensureConfigValidationFailure(t, "Dialect", Config.Dialect)
 	Config.Dialect = testDbDialect
+
+	// AccessKeyEncryption: empty is allowed (no encryption)
+	Config.AccessKeyEncryption = ""
+	validateConfig()
+
+	// AccessKeyEncryption: valid 32-byte key
+	Config.AccessKeyEncryption = testCookieHash
+	validateConfig()
+
+	// AccessKeyEncryption: invalid base64
+	Config.AccessKeyEncryption = "not-valid-base64!!!"
+	ensureConfigValidationFailure(t, "AccessKeyEncryption", Config.AccessKeyEncryption)
+
+	// AccessKeyEncryption: valid base64 but wrong size (48 bytes)
+	Config.AccessKeyEncryption = "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
+	ensureConfigValidationFailure(t, "AccessKeyEncryption", Config.AccessKeyEncryption)
+	Config.AccessKeyEncryption = testCookieHash
 }


### PR DESCRIPTION
Refuse to start if access_key_encryption is not valid base64 or decodes to an invalid AES key size (must be 16, 24, or 32 bytes). Previously a misconfigured key (e.g. 48 bytes) would only surface as a cryptic "crypto/aes: invalid key size" error when trying to store a secret.
