### PR TITLE
feat(api): add HTTP access request logging

### DIFF
--- a/api/access_log.go
+++ b/api/access_log.go
@@ -3,6 +3,7 @@ package api
 import (
 	"io"
 	"net/http"
+	"strings"
 	"time"
 
 	"github.com/gorilla/handlers"
@@ -10,7 +11,7 @@ import (
 )
 
 func accessLogFormatter(_ io.Writer, params handlers.LogFormatterParams) {
-	if params.URL.Path == "/api/ping" {
+	if strings.HasSuffix(params.URL.Path, "/api/ping") {
 		return
 	}
 	log.WithFields(log.Fields{

--- a/api/access_log.go
+++ b/api/access_log.go
@@ -21,7 +21,7 @@ func accessLogFormatter(_ io.Writer, params handlers.LogFormatterParams) {
 		"size":     params.Size,
 		"duration": time.Since(params.TimeStamp).String(),
 		"remote":   params.Request.RemoteAddr,
-	}).Info("http request")
+	}).Debug("http request")
 }
 
 func AccessLogMiddleware(next http.Handler) http.Handler {

--- a/api/access_log.go
+++ b/api/access_log.go
@@ -1,0 +1,28 @@
+package api
+
+import (
+	"io"
+	"net/http"
+	"time"
+
+	"github.com/gorilla/handlers"
+	log "github.com/sirupsen/logrus"
+)
+
+func accessLogFormatter(_ io.Writer, params handlers.LogFormatterParams) {
+	if params.URL.Path == "/api/ping" {
+		return
+	}
+	log.WithFields(log.Fields{
+		"method":   params.Request.Method,
+		"path":     params.URL.Path,
+		"status":   params.StatusCode,
+		"size":     params.Size,
+		"duration": time.Since(params.TimeStamp).String(),
+		"remote":   params.Request.RemoteAddr,
+	}).Info("http request")
+}
+
+func AccessLogMiddleware(next http.Handler) http.Handler {
+	return handlers.CustomLoggingHandler(nil, next, accessLogFormatter)
+}

--- a/api/access_log_test.go
+++ b/api/access_log_test.go
@@ -51,11 +51,14 @@ func TestAccessLogMiddleware_SkipsPing(t *testing.T) {
 		w.WriteHeader(http.StatusOK)
 	}))
 
-	req := httptest.NewRequest("GET", "/api/ping", nil)
-	rr := httptest.NewRecorder()
-	handler.ServeHTTP(rr, req)
+	for _, path := range []string{"/api/ping", "/semaphore/api/ping"} {
+		hook.Reset()
+		req := httptest.NewRequest("GET", path, nil)
+		rr := httptest.NewRecorder()
+		handler.ServeHTTP(rr, req)
 
-	if len(hook.Entries) != 0 {
-		t.Errorf("expected no log entries for /api/ping, got %d", len(hook.Entries))
+		if len(hook.Entries) != 0 {
+			t.Errorf("expected no log entries for %s, got %d", path, len(hook.Entries))
+		}
 	}
 }

--- a/api/access_log_test.go
+++ b/api/access_log_test.go
@@ -10,6 +10,7 @@ import (
 )
 
 func TestAccessLogMiddleware(t *testing.T) {
+	log.SetLevel(log.DebugLevel)
 	hook := test.NewLocal(log.StandardLogger())
 
 	handler := AccessLogMiddleware(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -27,6 +28,9 @@ func TestAccessLogMiddleware(t *testing.T) {
 	}
 
 	entry := hook.LastEntry()
+	if entry.Level != log.DebugLevel {
+		t.Errorf("expected debug level, got %v", entry.Level)
+	}
 	for _, field := range []string{"method", "path", "status", "size", "duration", "remote"} {
 		if _, ok := entry.Data[field]; !ok {
 			t.Errorf("missing expected log field %q", field)

--- a/api/access_log_test.go
+++ b/api/access_log_test.go
@@ -1,0 +1,61 @@
+package api
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	log "github.com/sirupsen/logrus"
+	"github.com/sirupsen/logrus/hooks/test"
+)
+
+func TestAccessLogMiddleware(t *testing.T) {
+	hook := test.NewLocal(log.StandardLogger())
+
+	handler := AccessLogMiddleware(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte("ok"))
+	}))
+
+	req := httptest.NewRequest("GET", "/api/projects", nil)
+	req.RemoteAddr = "192.0.2.1:12345"
+	rr := httptest.NewRecorder()
+	handler.ServeHTTP(rr, req)
+
+	if len(hook.Entries) != 1 {
+		t.Fatalf("expected 1 log entry, got %d", len(hook.Entries))
+	}
+
+	entry := hook.LastEntry()
+	for _, field := range []string{"method", "path", "status", "size", "duration", "remote"} {
+		if _, ok := entry.Data[field]; !ok {
+			t.Errorf("missing expected log field %q", field)
+		}
+	}
+
+	if entry.Data["method"] != "GET" {
+		t.Errorf("expected method GET, got %v", entry.Data["method"])
+	}
+	if entry.Data["path"] != "/api/projects" {
+		t.Errorf("expected path /api/projects, got %v", entry.Data["path"])
+	}
+	if entry.Data["status"] != http.StatusOK {
+		t.Errorf("expected status %d, got %v", http.StatusOK, entry.Data["status"])
+	}
+}
+
+func TestAccessLogMiddleware_SkipsPing(t *testing.T) {
+	hook := test.NewLocal(log.StandardLogger())
+
+	handler := AccessLogMiddleware(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	req := httptest.NewRequest("GET", "/api/ping", nil)
+	rr := httptest.NewRecorder()
+	handler.ServeHTTP(rr, req)
+
+	if len(hook.Entries) != 0 {
+		t.Errorf("expected no log entries for /api/ping, got %d", len(hook.Entries))
+	}
+}

--- a/cli/cmd/root.go
+++ b/cli/cmd/root.go
@@ -197,6 +197,7 @@ func runService() {
 
 	var router http.Handler = route
 
+	router = api.AccessLogMiddleware(router)
 	router = handlers.ProxyHeaders(router)
 	http.Handle("/", router)
 


### PR DESCRIPTION
Log every HTTP request with method, path, status code, duration, and
remote address using logrus structured fields. Middleware is placed
after ProxyHeaders so remote address reflects X-Forwarded-For.

/api/ping health checks are not logged.