### PR TITLE
feat: randomize runner selection

### DIFF
--- a/services/tasks/RemoteJob.go
+++ b/services/tasks/RemoteJob.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"math/rand/v2"
 	"net/http"
 	"time"
 
@@ -91,6 +92,18 @@ func callRunnerWebhook(runner *db.Runner, tsk *TaskRunner, action string) (err e
 	return
 }
 
+func shuffleRunners(rs []db.Runner) []db.Runner {
+	if len(rs) < 2 {
+		return rs
+	}
+
+	rand.Shuffle(len(rs), func(i, j int) {
+		rs[i], rs[j] = rs[j], rs[i]
+	})
+
+	return rs
+}
+
 func (t *RemoteJob) Run(username string, incomingVersion *string, alias string) (err error) {
 
 	tsk, err := t.taskPool.GetTask(t.Task.ID)
@@ -115,11 +128,15 @@ func (t *RemoteJob) Run(username string, incomingVersion *string, alias string) 
 		if err != nil {
 			return
 		}
+		projectRunners = shuffleRunners(projectRunners)
+
 		var globalRunners []db.Runner
 		globalRunners, err = t.taskPool.store.GetAllRunners(true, true)
 		if err != nil {
 			return
 		}
+		globalRunners = shuffleRunners(globalRunners)
+
 		runners = append(runners, projectRunners...)
 		runners = append(runners, globalRunners...)
 	})

--- a/services/tasks/RemoteJob.go
+++ b/services/tasks/RemoteJob.go
@@ -2,10 +2,11 @@ package tasks
 
 import (
 	"bytes"
+	"crypto/rand"
 	"encoding/json"
 	"errors"
 	"fmt"
-	"math/rand/v2"
+	"math/big"
 	"net/http"
 	"time"
 
@@ -97,9 +98,14 @@ func shuffleRunners(rs []db.Runner) []db.Runner {
 		return rs
 	}
 
-	rand.Shuffle(len(rs), func(i, j int) {
-		rs[i], rs[j] = rs[j], rs[i]
-	})
+	for i, _ := range rs {
+		j, err := rand.Int(rand.Reader, big.NewInt(int64(len(rs))))
+		if err != nil {
+			panic(err)
+		}
+
+		rs[i], rs[j.Int64()] = rs[j.Int64()], rs[i]
+	}
 
 	return rs
 }

--- a/services/tasks/RemoteJob.go
+++ b/services/tasks/RemoteJob.go
@@ -98,16 +98,24 @@ func shuffleRunners(rs []db.Runner) []db.Runner {
 		return rs
 	}
 
-	for i, _ := range rs {
-		j, err := rand.Int(rand.Reader, big.NewInt(int64(len(rs))))
+	// Work on a copy so that if randomness fails, we can safely return the original order.
+	shuffled := make([]db.Runner, len(rs))
+	copy(shuffled, rs)
+
+	// Fisher–Yates shuffle using crypto/rand: for each i, pick j in [0, i].
+	for i := len(shuffled) - 1; i > 0; i-- {
+		max := big.NewInt(int64(i + 1))
+		j, err := rand.Int(rand.Reader, max)
 		if err != nil {
-			panic(err)
+			log.WithError(err).Warn("failed to shuffle runners, using original order")
+			return rs
 		}
 
-		rs[i], rs[j.Int64()] = rs[j.Int64()], rs[i]
+		ji := int(j.Int64())
+		shuffled[i], shuffled[ji] = shuffled[ji], shuffled[i]
 	}
 
-	return rs
+	return shuffled
 }
 
 func (t *RemoteJob) Run(username string, incomingVersion *string, alias string) (err error) {


### PR DESCRIPTION
Hello!

Just ran into same issue as mentioned here:
https://github.com/semaphoreui/semaphore/issues/1519#issuecomment-2306300463

>I noticed the selection of the runners for task execution was not random.
>[...]
> Is there anyway this behaviour can be changed? Ideally the runner selection, as its most basic form, is completely random, or just straight round robin?

For me, tasks also kept scheduling on the same runner

Seems that issue is fixed by adding 2 shuffle calls, still keeping "project" runners preferred over "global" ones

To verify that tasks are distributed randomly, I've built and ran docker image locally:

- before: A, A, A, A, A, A -> `semaphoreui/semaphore:v2.17.28`
- after: A, A, B, B, A, B -> `agrrh/semaphoreui:random-runner-selection`

(First contribution here, please, let me know if I missed something)