### PR TITLE
feat(ui): Add quick search filter to the Task Templates view

### DIFF
--- a/web/src/lang/de.js
+++ b/web/src/lang/de.js
@@ -214,6 +214,7 @@ export default {
   editViews: 'Ansichten bearbeiten',
   newTemplate: 'Neue Vorlage',
   taskTemplates2: 'Task-Vorlagen',
+  search: 'Suche',
   all: 'Alle',
   notLaunched: 'Nicht gestartet',
   by: 'von {user_name}',

--- a/web/src/lang/en.js
+++ b/web/src/lang/en.js
@@ -385,4 +385,5 @@ export default {
   role_required: 'Role is required',
 
   templatePermission: 'Template permissions',
+  search: 'Search',
 };

--- a/web/src/lang/es.js
+++ b/web/src/lang/es.js
@@ -205,6 +205,7 @@ export default {
   editViews: 'Editar Vistas',
   newTemplate: 'Nueva plantilla',
   taskTemplates2: 'Plantillas de Tareas',
+  search: 'Buscar',
   all: 'Todo',
   notLaunched: 'No lanzado',
   by: 'por {user_name}',

--- a/web/src/lang/fr.js
+++ b/web/src/lang/fr.js
@@ -205,6 +205,7 @@ export default {
   editViews: 'Modifier les vues',
   newTemplate: 'Nouveau modèle',
   taskTemplates2: 'Modèles de tâches',
+  search: 'Recherche',
   all: 'Tous',
   notLaunched: 'Non lancé',
   by: 'par {user_name}',

--- a/web/src/lang/it.js
+++ b/web/src/lang/it.js
@@ -205,6 +205,7 @@ export default {
   editViews: 'Modifica viste',
   newTemplate: 'Nuovo modello',
   taskTemplates2: 'Modelli di compito',
+  search: 'Cerca',
   all: 'Tutti',
   notLaunched: 'Non avviato',
   by: 'da {user_name}',

--- a/web/src/lang/ja.js
+++ b/web/src/lang/ja.js
@@ -205,6 +205,7 @@ export default {
   editViews: 'ビューを編集',
   newTemplate: '新しいテンプレート',
   taskTemplates2: 'タスクテンプレート',
+  search: '検索',
   all: 'すべて',
   notLaunched: '未起動',
   by: '{user_name}による',

--- a/web/src/lang/ko.js
+++ b/web/src/lang/ko.js
@@ -205,6 +205,7 @@ export default {
   editViews: '보기 수정',
   newTemplate: '새 템플릿',
   taskTemplates2: '작업 템플릿',
+  search: '검색',
   all: '모두',
   notLaunched: '시작되지 않음',
   by: '{user_name}에 의해',

--- a/web/src/lang/nl.js
+++ b/web/src/lang/nl.js
@@ -205,6 +205,7 @@ export default {
   editViews: 'Weergaven Bewerken',
   newTemplate: 'Nieuw sjabloon',
   taskTemplates2: 'Taak Sjablonen',
+  search: 'Zoeken',
   all: 'Alle',
   notLaunched: 'Niet gelanceerd',
   by: 'door {user_name}',

--- a/web/src/lang/pl.js
+++ b/web/src/lang/pl.js
@@ -205,6 +205,7 @@ export default {
   editViews: 'Edytuj widoki',
   newTemplate: 'Nowy szablon',
   taskTemplates2: 'Szablony zadań',
+  search: 'Szukaj',
   all: 'Wszystko',
   notLaunched: 'Nie uruchomiono',
   by: 'przez {user_name}',

--- a/web/src/lang/pt.js
+++ b/web/src/lang/pt.js
@@ -205,6 +205,7 @@ export default {
   editViews: 'Editar Visualizações',
   newTemplate: 'Novo modelo',
   taskTemplates2: 'Modelos de Tarefa',
+  search: 'Pesquisar',
   all: 'Todos',
   notLaunched: 'Não lançado',
   by: 'por {user_name}',

--- a/web/src/lang/pt_br.js
+++ b/web/src/lang/pt_br.js
@@ -205,6 +205,7 @@ export default {
   editViews: 'Editar Visualizações',
   newTemplate: 'Novo modelo',
   taskTemplates2: 'Modelos de Tarefa',
+  search: 'Pesquisar',
   all: 'Todos',
   notLaunched: 'Não lançado',
   by: 'por {user_name}',

--- a/web/src/lang/ru.js
+++ b/web/src/lang/ru.js
@@ -350,4 +350,5 @@ export default {
   project_stats: 'Статистика',
   allow_override_branch: 'Ветка',
   template_common_options: 'Общие параметры',
+  search: 'Поиск',
 };

--- a/web/src/lang/uk.js
+++ b/web/src/lang/uk.js
@@ -206,6 +206,7 @@ export default {
   editViews: 'Редагувати перегляди',
   newTemplate: 'Новий шаблон',
   taskTemplates2: 'Шаблони завдань',
+  search: 'Пошук',
   all: 'Усі',
   notLaunched: 'Не запущено',
   by: 'від {user_name}',

--- a/web/src/lang/zh_cn.js
+++ b/web/src/lang/zh_cn.js
@@ -205,6 +205,7 @@ export default {
   editViews: '编辑视图',
   newTemplate: '新模板',
   taskTemplates2: '任务模板',
+  search: '搜索',
   all: '所有',
   notLaunched: '未启动',
   by: '由 {user_name}',

--- a/web/src/lang/zh_tw.js
+++ b/web/src/lang/zh_tw.js
@@ -207,6 +207,7 @@ export default {
   editViews: '編輯檢視',
   newTemplate: '新增範本',
   taskTemplates2: '任務範本',
+  search: '搜尋',
   all: '所有',
   notLaunched: '未啟動',
   by: '由 {user_name}',

--- a/web/src/views/project/Templates.vue
+++ b/web/src/views/project/Templates.vue
@@ -51,6 +51,17 @@
       </v-toolbar-title>
       <v-spacer></v-spacer>
 
+      <v-text-field
+        v-model="search"
+        append-icon="mdi-magnify"
+        :label="$t('search')"
+        clearable
+        single-line
+        hide-details
+        class="mr-4"
+        style="max-width: 300px;"
+      ></v-text-field>
+
       <v-menu
         offset-y
       >
@@ -138,6 +149,7 @@
       :headers="filteredHeaders"
       :items="items"
       :items-per-page="Number.MAX_VALUE"
+      :search="search"
       :expanded.sync="openedItems"
       :style="{
         opacity: viewItemsLoading ? 0.3 : 1,
@@ -311,6 +323,7 @@ export default {
       viewTab: null,
       apps: null,
       itemApp: '',
+      search: '',
     };
   },
 


### PR DESCRIPTION
## Description
When working with a large number of Task Templates, manually scrolling through them becomes tedious and inefficient.
This PR adds a quick, client-side search input filter to the Task Templates table. 

## Changes Made
- Added a `<v-text-field>` in the `Templates.vue` toolbar for the search input.
- Bound the search query to the existing `v-data-table`'s built-in search property.
- Added translation key `search` to `en.js` and `ru.js` localization files.

## How to Test
1. Navigate to navigating to the `Task Templates` section.
2. Type in the text field at the top right of the toolbar.
3. The list is automatically filtered locally based on query criteria.