### PR TITLE
Upgrade Go to 1.26 and Alpine to 3.22

### DIFF
--- a/.github/workflows/community_beta.yml
+++ b/.github/workflows/community_beta.yml
@@ -1,6 +1,6 @@
 name: Community Beta
 
-'on':
+on:
   push:
     tags:
       - v*-beta*
@@ -19,7 +19,7 @@ jobs:
       - name: Setup golang
         uses: actions/setup-go@v5
         with:
-          go-version: '^1.24.6'
+          go-version: '1.26'
 
       - name: Setup nodejs
         uses: actions/setup-node@v4

--- a/.github/workflows/community_release.yml
+++ b/.github/workflows/community_release.yml
@@ -1,6 +1,6 @@
 name: Community Release
 
-'on':
+on:
   push:
     tags:
       - 'v[0-9]+.[0-9]+.[0-9]+'
@@ -20,7 +20,7 @@ jobs:
       - name: Setup golang
         uses: actions/setup-go@v5
         with:
-          go-version: '^1.24.6'
+          go-version: '1.26'
 
       - name: Setup nodejs
         uses: actions/setup-node@v4
@@ -81,8 +81,6 @@ jobs:
           username: ${{ secrets.DOCKER_USER }}
           password: ${{ secrets.DOCKER_PASS }}
 
-
-
       - name: Server meta
         id: server
         uses: docker/metadata-action@v5
@@ -136,8 +134,6 @@ jobs:
           push: ${{ github.event_name != 'pull_request' }}
           labels: ${{ steps.server.outputs.labels }}
           tags: semaphoreui/semaphore-community:${{ github.ref_name }}-powershell7.5.0
-
-
 
       - name: Runner meta
         id: runner

--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -1,6 +1,6 @@
 name: Dev
 
-'on':
+on:
   push:
     branches:
       - develop
@@ -20,7 +20,7 @@ jobs:
       - name: Setup golang
         uses: actions/setup-go@v5
         with:
-          go-version: '^1.24.6'
+          go-version: '1.26'
 
       - name: Setup nodejs
         uses: actions/setup-node@v4
@@ -254,7 +254,7 @@ jobs:
       - name: Setup golang
         uses: actions/setup-go@v5
         with:
-          go-version: '^1.24.6'
+          go-version: '1.26'
 
       - name: Setup nodejs
         uses: actions/setup-node@v4
@@ -335,7 +335,7 @@ jobs:
       - name: Setup golang
         uses: actions/setup-go@v5
         with:
-          go-version: '^1.24.6'
+          go-version: '1.26'
 
       - name: Setup nodejs
         uses: actions/setup-node@v4
@@ -415,7 +415,7 @@ jobs:
       - name: Setup golang
         uses: actions/setup-go@v5
         with:
-          go-version: '^1.24.6'
+          go-version: '1.26'
 
       - name: Setup nodejs
         uses: actions/setup-node@v4
@@ -480,7 +480,7 @@ jobs:
       - name: Setup golang
         uses: actions/setup-go@v5
         with:
-          go-version: '^1.24.6'
+          go-version: '1.26'
 
       - name: Setup nodejs
         uses: actions/setup-node@v4

--- a/.github/workflows/pro_selfhosted_beta.yml
+++ b/.github/workflows/pro_selfhosted_beta.yml
@@ -1,6 +1,6 @@
 name: Pro Self-Hosted Release
 
-'on':
+on:
   push:
     tags:
       - v*-beta*
@@ -20,7 +20,7 @@ jobs:
       - name: Setup golang
         uses: actions/setup-go@v5
         with:
-          go-version: '^1.24.6'
+          go-version: '1.26'
 
       - name: Setup nodejs
         uses: actions/setup-node@v4
@@ -97,8 +97,6 @@ jobs:
           username: ${{ secrets.DOCKER_USER }}
           password: ${{ secrets.DOCKER_PASS }}
 
-
-
       - name: Server meta
         id: server
         uses: docker/metadata-action@v5
@@ -174,8 +172,6 @@ jobs:
           cache-from: type=gha
           cache-to: type=gha,mode=max
           provenance: false
-
-
 
       - name: Runner meta
         id: runner

--- a/.github/workflows/pro_selfhosted_release.yml
+++ b/.github/workflows/pro_selfhosted_release.yml
@@ -1,6 +1,6 @@
 name: Pro Self-Hosted Release
 
-'on':
+on:
   push:
     tags:
       - 'v[0-9]+.[0-9]+.[0-9]+'
@@ -19,7 +19,7 @@ jobs:
       - name: Setup golang
         uses: actions/setup-go@v5
         with:
-          go-version: '^1.24.6'
+          go-version: '1.26'
 
       - name: Setup nodejs
         uses: actions/setup-node@v4
@@ -95,8 +95,6 @@ jobs:
         with:
           username: ${{ secrets.DOCKER_USER }}
           password: ${{ secrets.DOCKER_PASS }}
-
-
 
       - name: Server meta
         id: server
@@ -175,8 +173,6 @@ jobs:
           cache-from: type=gha
           cache-to: type=gha,mode=max
           provenance: false
-
-
 
       - name: Runner meta
         id: runner

--- a/deployment/docker/dredd/Dockerfile
+++ b/deployment/docker/dredd/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.24-alpine3.21 as golang
+FROM golang:1.26-alpine3.22 as golang
 
 RUN apk add --no-cache -U \
     curl git

--- a/deployment/docker/runner/Dockerfile
+++ b/deployment/docker/runner/Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=$BUILDPLATFORM golang:1.24-alpine3.21 as builder
+FROM --platform=$BUILDPLATFORM golang:1.26-alpine3.22 as builder
 
 RUN apk add --no-cache -U \
     libc-dev curl nodejs npm git gcc zip unzip tar
@@ -45,7 +45,7 @@ RUN curl -O https://releases.hashicorp.com/terraform/${TERRAFORM_VERSION}/terraf
 RUN wget -O /tmp/terragrunt https://github.com/gruntwork-io/terragrunt/releases/download/v${TERRAGRUNT_VERSION}/terragrunt_linux_${TARGETARCH} && \
     chmod +x /tmp/terragrunt
 
-FROM alpine:3.21
+FROM alpine:3.22
 
 ARG TARGETARCH="amd64"
 

--- a/deployment/docker/server/Dockerfile
+++ b/deployment/docker/server/Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=$BUILDPLATFORM golang:1.24-alpine3.21 as builder
+FROM --platform=$BUILDPLATFORM golang:1.26-alpine3.22 as builder
 
 RUN apk add --no-cache -U \
     libc-dev curl nodejs npm git gcc zip unzip tar
@@ -46,7 +46,7 @@ RUN curl -O https://releases.hashicorp.com/terraform/${TERRAFORM_VERSION}/terraf
 RUN wget -O /tmp/terragrunt https://github.com/gruntwork-io/terragrunt/releases/download/v${TERRAGRUNT_VERSION}/terragrunt_linux_${TARGETARCH} && \
     chmod +x /tmp/terragrunt
 
-FROM alpine:3.21
+FROM alpine:3.22
 
 ARG TARGETARCH="amd64"
 # renovate: datasource=pypi depName=ansible


### PR DESCRIPTION
Bump Go to 1.26 and Alpine to 3.22.

Go 1.24 has reached EOL, and newer Go versions are now built against Alpine 3.22+, so this keeps us on a supported and compatible setup. No functional changes expected.