### PR TITLE
fix(runners): gate one-off shutdown on acknowledged progress upload

### DIFF
--- a/services/runners/job_pool.go
+++ b/services/runners/job_pool.go
@@ -239,7 +239,7 @@ func (p *JobPool) Run() {
 					fmt.Println("Runner connected")
 				}
 
-				if util.Config.Runner.OneOff && len(p.runningJobs) > 0 && !p.hasRunningJobs() {
+				if util.Config.Runner.OneOff && ok && len(p.runningJobs) > 0 && !p.hasRunningJobs() {
 					os.Exit(0)
 				}
 


### PR DESCRIPTION
### Motivation
- Prevent the runner from exiting in one-off mode before the latest progress/status upload is acknowledged so completed jobs remain retryable after transient PUT failures.

### Description
- Require `sendProgress()` to return `true` (`ok == true`) before calling `os.Exit(0)` in the `JobPool` request timer loop (`services/runners/job_pool.go`).

### Testing
- Ran `go test ./services/runners/...`, which succeeded (package has no test files: `? github.com/semaphoreui/semaphore/services/runners [no test files]`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cc17806f8483258a2e31aaa4f65133)