### PR TITLE
docs: update README to use SQLite instead of Bolt (deprecated)

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ The most popular way to install Semaphore is via Docker.
 
 ```
 docker run -p 3000:3000 --name semaphore \
-	-e SEMAPHORE_DB_DIALECT=bolt \
+	-e SEMAPHORE_DB_DIALECT=sqlite \
 	-e SEMAPHORE_ADMIN=admin \
 	-e SEMAPHORE_ADMIN_PASSWORD=changeme \
 	-e SEMAPHORE_ADMIN_NAME=Admin \


### PR DESCRIPTION
Updated the README: switched the example from Bolt to SQLite, as Bolt is now deprecated.